### PR TITLE
a quick fix to make the contentType works

### DIFF
--- a/scalate-spring-mvc/src/main/scala/org/fusesource/scalate/spring/view/ScalateViewResolver.scala
+++ b/scalate-spring-mvc/src/main/scala/org/fusesource/scalate/spring/view/ScalateViewResolver.scala
@@ -43,6 +43,11 @@ class ScalateViewResolver() extends AbstractTemplateViewResolver {
       view = urlView
     }
 
+    val contentType = getContentType
+    if (contentType != null) {
+      view.setContentType(contentType)
+    }
+
     view.asInstanceOf[AbstractUrlBasedView]
   }
 


### PR DESCRIPTION
scalate-spring-mvc has a bug that contentType doesn't work
the reason is that ScalateViewResolver.buildView should invoke super.buildView but didn't
but adding super.buildView makes more problem
so I just copy some code from super.buildView, just fix the contentType
