### PR TITLE
Fix typo

### DIFF
--- a/samples/scalate-sample/src/test/scala/org/fusesource/scalate/sample/SampleTest.scala
+++ b/samples/scalate-sample/src/test/scala/org/fusesource/scalate/sample/SampleTest.scala
@@ -117,7 +117,7 @@ class SampleTest extends FunSuite with WebServerMixin with WebDriverMixin {
     "- for (i &lt;-")
 
   testPageContains("scaml/errors/templateCompileError.scaml",
-    "Inconsistent indent level detected: intended too shallow",
+    "Inconsistent indent level detected: indented too shallow",
     "in /scaml/errors/templateCompileError.scaml near line 23 col 4",
     "%h1 Template Compiler Error")
 

--- a/scalate-core/src/main/scala/org/fusesource/scalate/scaml/ScamlParser.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/scaml/ScamlParser.scala
@@ -88,7 +88,7 @@ class IndentedParser extends RegexParsers() {
       var rc: Parser[Any] = mismatch_indent ~ err("Inconsistent indent detected: indented with "+mismatch_indent_desc+" but previous lines were indented with "+indent_desc)
       if( strict ) {
         // Look for indents that are too deep.
-        rc |= repN(indent_level,indent_unit)~"""[ \t]+""".r~err("Inconsistent indent level detected: intended too deep")
+        rc |= repN(indent_level,indent_unit)~"""[ \t]+""".r~err("Inconsistent indent level detected: indented too deep")
         // eat empty lines..
         rc |= rep(indent_unit) ~ """\r?\n""".r ~> current_indent(strict)
       }
@@ -103,7 +103,7 @@ class IndentedParser extends RegexParsers() {
 
       if( indent_level > 0 ) {
         // Look for indents that are too shallow
-        rc |= repN(indent_level-1,indent_unit)~"""[ \t]+""".r~err("Inconsistent indent level detected: intended too shallow")
+        rc |= repN(indent_level-1,indent_unit)~"""[ \t]+""".r~err("Inconsistent indent level detected: indented too shallow")
       }
 
       rc | failure("Inconsistent indent detected: "+indent_level+" indent level(s) were expected");
@@ -359,7 +359,7 @@ class ScamlParser(val upto_type:String=UPTO_TYPE_SINGLE_LINE) extends IndentedPa
   def statement_block = rep(indent(statement, true))
 
   def parser = rep(
-    space ~ err("Inconsistent indent level detected: intended too shallow") ^^ { null } |
+    space ~ err("Inconsistent indent level detected: indented too shallow") ^^ { null } |
     nl ^^ { x=> Newline() } |
     statement
   ) ^^ { case x=> x.filter(_ != Newline()) } 

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scaml/ScamlTemplateErrorTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scaml/ScamlTemplateErrorTest.scala
@@ -57,32 +57,32 @@ class ScamlTemplateErrorTest extends ScamlTestSupport {
 </html>
 """)
 
-  testInvalidSyntaxException("Inconsistent indent level detected: intended too shallow",
+  testInvalidSyntaxException("Inconsistent indent level detected: indented too shallow",
 """
 %html
   %two
    %tooshallow
   %two
 """,
-"Inconsistent indent level detected: intended too shallow at 3.4")
+"Inconsistent indent level detected: indented too shallow at 3.4")
 
-  testInvalidSyntaxException("Inconsistent indent level detected: intended too shallow at root",
+  testInvalidSyntaxException("Inconsistent indent level detected: indented too shallow at root",
 """
 %html
   %two
  %toodeep
   %two
 """,
-"Inconsistent indent level detected: intended too shallow at 3.2")
+"Inconsistent indent level detected: indented too shallow at 3.2")
 
-  testInvalidSyntaxException("Inconsistent indent level detected: intended too deep",
+  testInvalidSyntaxException("Inconsistent indent level detected: indented too deep",
 """
 %html
   %two
      %toodeep
   %two
 """,
-"Inconsistent indent level detected: intended too deep at 3.6")
+"Inconsistent indent level detected: indented too deep at 3.6")
 
   testInvalidSyntaxException("Inconsistent indent detected: indented with spaces but previous lines were indented with tabs",
 """


### PR DESCRIPTION
Error message "Inconsistent indent level detected: intended too shallow" should be "indented" rather than "intended".
