### PR TITLE
ScalateAtmosphereModule/Servlet

### DIFF
--- a/scalate-guice/pom.xml
+++ b/scalate-guice/pom.xml
@@ -54,6 +54,13 @@
       <version>${jersey-version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.atmosphere</groupId>
+      <artifactId>atmosphere-jersey</artifactId>
+      <version>0.8.0-RC1</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>org.scalatest</groupId>

--- a/scalate-guice/src/main/scala/org/fusesource/scalate/guice/ScalateAtmosphereModule.scala
+++ b/scalate-guice/src/main/scala/org/fusesource/scalate/guice/ScalateAtmosphereModule.scala
@@ -1,0 +1,31 @@
+package org.fusesource.scalate.guice
+
+import collection.JavaConverters._
+
+/**
+ * ScalateModule that also configures the Atmosphere framework
+ * which here acts as an extension to Jersey for developing
+ * Comet/WebSocket resources.
+ *
+ * @author Sven Jacobs <mail@svenjacobs.com>
+ */
+class ScalateAtmosphereModule extends ScalateModule {
+
+  override def configureServlets() {
+    // We don't need to call super.applyJerseyFilter here because Atmosphere
+    // will configure / is using Jersey
+    applyScalateServlets
+    applyAtmosphereServlets()
+  }
+
+  protected def applyAtmosphereServlets() {
+    val props: Map[String, String] = (for ((name, value) <- createResourceConfigProperties) yield (name, value.toString)) ++ Map(
+      "org.atmosphere.useWebSocket" -> "true",
+      "org.atmosphere.useNative" -> "true"
+    )
+
+    // This regex matches everything except when the URI ends with common file extensions (.js, .css, etc)
+    val regex = "^/.*(?<!\\.%s)$" format fileExtensionsExcludedFromJersey.mkString("(?:", "|", ")")
+    serveRegex(regex).`with`(classOf[ScalateAtmosphereServlet], props.asJava)
+  }
+}

--- a/scalate-guice/src/main/scala/org/fusesource/scalate/guice/ScalateAtmosphereServlet.scala
+++ b/scalate-guice/src/main/scala/org/fusesource/scalate/guice/ScalateAtmosphereServlet.scala
@@ -1,0 +1,48 @@
+package org.fusesource.scalate.guice
+
+import javax.servlet.ServletConfig
+import com.google.inject.{Inject, Injector, Singleton}
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer
+import org.atmosphere.cpr.AtmosphereServlet
+import org.atmosphere.handler.ReflectorServletProcessor
+
+/**
+ * Atmosphere servlet configured by Scalate/Guice
+ *
+ * @author Sven Jacobs <mail@svenjacobs.com>
+ */
+@Singleton
+class ScalateAtmosphereServlet @Inject() (private val injector: Injector) extends AtmosphereServlet {
+
+  /**
+   * Most of the code to set up AtmosphereServlet has been borrowed from
+   * {@link org.atmosphere.guice.AtmosphereGuiceServlet#detectSupportedFramework}
+   */
+  override def detectSupportedFramework(sc: ServletConfig): Boolean = {
+    import AtmosphereServlet._
+
+    setDefaultBroadcasterClassName(JERSEY_BROADCASTER)
+
+    val guiceContainer = injector.getInstance(classOf[GuiceContainer])
+//    val resourceConfig = injector.getInstance(classOf[ResourceConfig])
+
+    val rsp = new ReflectorServletProcessor()
+    rsp.setServlet(guiceContainer)
+
+//    val props = resourceConfig.getProperties.asScala
+//
+//    for ((name, value) <- props) {
+//      if (value.isInstanceOf[String]) {
+//        addInitParameter(name, value.asInstanceOf[String])
+//      }
+//    }
+
+    var mapping = sc.getInitParameter(PROPERTY_SERVLET_MAPPING)
+    if (mapping == null) mapping = "/*"
+
+    getAtmosphereConfig.setSupportSession(false)
+    addAtmosphereHandler(mapping, rsp)
+
+    true
+  }
+}


### PR DESCRIPTION
Hey there,

I've developed two Atmosphere (https://github.com/Atmosphere/atmosphere) related classes for Scalate that permit using Atmosphere as an extension to Jersey (when also using Guice).

ScalateAtmosphereModule should be used as an replacement for ScalateModule.

I thought maybe other people find this useful, too.
