### PR TITLE
Fix bug at the example "Hello Hiram Chirino from Tampa."

### DIFF
--- a/scalate-website/src/documentation/_scalate-embedding-guide.md
+++ b/scalate-website/src/documentation/_scalate-embedding-guide.md
@@ -26,7 +26,7 @@ val output = engine.layout("/path/to/template.ssp")
 
 Variables can passed as attributes to the template via the render context.  For example:
 {pygmentize:: scala}
-val output = engine.layout("/foo/bar.scaml", Map("name" -> "Hiram", "city" -> "Tampa"))
+val output = engine.layout("/foo/bar.scaml", Map("name" -> ("Hiram", "Chirino"), "city" -> "Tampa"))
 {pygmentize}
 
 A template can then access those attributes once they declare a variable binding.  For example:


### PR DESCRIPTION
"Chirino" is missing from the data.
