### PR TITLE
Scalate supports Scala 2.9.1

### DIFF
--- a/scalate-website/src/index.page
+++ b/scalate-website/src/index.page
@@ -16,7 +16,7 @@ sort_info: 1
 Scalate: Scala Template Engine
 ==============================
 
-Scalate is a [Scala 2.8](http://www.scala-lang.org) based <a href="http://en.wikipedia.org/wiki/Template_engine_(web)">template engine</a> for generating text and markup which can be used in the following [frameworks](documentation/frameworks.html) and environments:
+Scalate is a [Scala 2.9.1](http://www.scala-lang.org) based <a href="http://en.wikipedia.org/wiki/Template_engine_(web)">template engine</a> for generating text and markup which can be used in the following [frameworks](documentation/frameworks.html) and environments:
 
 * stand alone in any JVM or as a [Servlet Filter](documentation/user-guide.html#using_scalate_as_servlet_filter_in_your_web_application) in any Java in a web application 
 * with JAXRS with [Jersey](https://jersey.dev.java.net/)


### PR DESCRIPTION
Scalate is a Scala 2.8 based template engine for generating text...
makes people think Scalate is no longer maintained because it only supports older version of Scala.
