### PR TITLE
Add support for sass/scss @import

### DIFF
--- a/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/Sass.scala
+++ b/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/Sass.scala
@@ -38,13 +38,12 @@ class Sass(val jruby:JRuby, val engine: TemplateEngine) extends Filter {
 
   def filter(context: RenderContext, content: String) = {
 
-    val sassPaths = List[String]()
     var result: StringBuffer = new StringBuffer
     jruby.put("@result", result)
     jruby.run(
       "require 'haml-3.0.25/lib/sass'",
       "options = {}",
-      "options[:load_paths] = ["+sassPaths.map("'"+_+"'").mkString(",")+"]",
+      "options[:load_paths] = ["+context.engine.sourceDirectories.map("'"+_+"'").mkString(",")+"]",
       "options[:cache_location] = '"+engine.workingDirectory+"/sass'",
       "options[:style] = " + (if (engine.isDevelopmentMode) ":expanded" else ":compressed") + "",
       "options[:line_comments] = " + (if (engine.isDevelopmentMode) "true" else "false") + "",


### PR DESCRIPTION
I found out the hard way that Scalate's support for sass @import was
broken. It seems it didn't know where to look (in the filesystem) for
any imported templates.

This change populates the `load_paths` sass exec option with the
`TemplateEngine`'s `sourceDirectories` list, letting sass know where to
look for files it wants to import.
I think this change makes the sass module behave the same as other
Scalate modules with respect to path searching.
