### PR TITLE
[#120] Made some classloader changes for running in an OSGi environment.

### DIFF
--- a/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
@@ -20,6 +20,7 @@ package org.fusesource.scalate
 import filter._
 import layout.{NullLayoutStrategy, LayoutStrategy}
 import mustache.MustacheCodeGenerator
+import osgi.BundleClassLoader
 import scaml.ScamlCodeGenerator
 import ssp.SspCodeGenerator
 import jade.JadeCodeGenerator
@@ -237,7 +238,10 @@ class TemplateEngine(var sourceDirectories: Traversable[File] = None, var mode: 
   
   private var _workingDirectory: File = null
 
-  var classLoader = this.getClass.getClassLoader
+  var classLoader = Thread.currentThread.getContextClassLoader match {
+    case BundleClassLoader(_) => Thread.currentThread.getContextClassLoader()
+    case _ => getClass().getClassLoader()
+  }
 
   /**
    * By default lets bind the context so we get to reuse its methods in a template

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/ScalaCompiler.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/ScalaCompiler.scala
@@ -52,7 +52,7 @@ class ScalaCompiler(bytecodeDirectory: File, classpath: String, combineClasspath
 
   val settings = generateSettings(bytecodeDirectory, classpath, combineClasspath)
 
-  val compiler = new Global(settings, null)
+  val compiler = createCompiler(settings)
 
   def compile(file: File): Unit = {
     synchronized {
@@ -135,6 +135,10 @@ class ScalaCompiler(bytecodeDirectory: File, classpath: String, combineClasspath
     //settings.make.value = "transitivenocp"
     settings
   }
+
+  protected def createCompiler(settings: Settings): Global = {
+    new Global(settings, null)
+  }
 }
 
 class OsgiScalaCompiler(val engine: TemplateEngine, val bundle: Bundle)
@@ -142,27 +146,29 @@ class OsgiScalaCompiler(val engine: TemplateEngine, val bundle: Bundle)
 
   debug("Using OSGi-enabled Scala compiler")
 
-  override val compiler = new Global(settings, null) {
-    lazy val internalClassPath = {
-      require(!forMSIL, "MSIL not supported")
-      createClassPath(super.classPath)
-    }
+  override protected def createCompiler(settings: Settings) = {
+    new Global(settings, null) {
+        lazy val internalClassPath = {
+          require(!forMSIL, "MSIL not supported")
+          createClassPath(super.classPath)
+        }
 
-    override def rootLoader = new loaders.JavaPackageLoader(internalClassPath.asInstanceOf[ClassPath[AbstractFile]])
+        override def rootLoader = new loaders.JavaPackageLoader(internalClassPath.asInstanceOf[ClassPath[AbstractFile]])
 
-    def createClassPath[T](original: ClassPath[T]) = {
-      var result = ListBuffer(original)
-      val files = List.concat(
-        BundleClassPathBuilder.fromBundle(bundle),
-        List(BundleClassPathBuilder.create(BundleClassLoader.unapply(classOf[scala.Application].getClassLoader).get.getBundle),
-             BundleClassPathBuilder.create(BundleClassLoader.unapply(classOf[ScalaCompiler].getClassLoader).get.getBundle),
-             BundleClassPathBuilder.create(BundleClassLoader.unapply(classOf[ClassPathBuilder].getClassLoader).get.getBundle)))
-      files.foreach(file => {
-        debug("Adding bundle " + file + " to the Scala compiler classpath")
-        result += original.context.newClassPath(file)
-      })
-      new MergedClassPath(result.toList.reverse, original.context)
-    }
+        def createClassPath[T](original: ClassPath[T]) = {
+          var result = ListBuffer(original)
+          val files = List.concat(
+            BundleClassPathBuilder.fromBundle(bundle),
+            List(BundleClassPathBuilder.create(BundleClassLoader.unapply(classOf[scala.Application].getClassLoader).get.getBundle),
+                 BundleClassPathBuilder.create(BundleClassLoader.unapply(classOf[ScalaCompiler].getClassLoader).get.getBundle),
+                 BundleClassPathBuilder.create(BundleClassLoader.unapply(classOf[ClassPathBuilder].getClassLoader).get.getBundle)))
+          files.foreach(file => {
+            debug("Adding bundle " + file + " to the Scala compiler classpath")
+            result += original.context.newClassPath(file)
+          })
+          new MergedClassPath(result.toList.reverse, original.context)
+        }
+      }
   }
 
   override protected def generateSettings(bytecodeDirectory: File, classpath: String, combineClasspath: Boolean): Settings = {


### PR DESCRIPTION
We use the same classloader selection mechanism at runtime as was there
for compile-time choosing for the OSGi/non OSGi environments. This
enables the running (compiled) template to reference other classes in
the classpath, but not necessarily in the classloader of
getClass().getClassLoader().

Also fixed the initialization code of the ScalaCompiler and
OsgiScalaCompiler to use a method for compiler creation. The
initialization of the ScalaCompiler.compiler was happening even when the
subclass overrode the .compiler field, causing it to fail in an OSGi
environment.  Now we just override the creation method, and it works as
expected.
