### PR TITLE
Do not retry template compilation twice

### DIFF
--- a/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
@@ -774,57 +774,51 @@ class TemplateEngine(var sourceDirectories: Traversable[File] = None, var mode: 
         }
 
       case e: CompilerException =>
-        // TODO: figure out why scala.tools.nsc.Global sometimes returns
-        // false compile errors that go away if you redo
-        if (attempt == 0) {
-          compileAndLoad(source, extraBindings, 1)
-        } else {
-          // Translate the scala error location info
-          // to the template locations..
-          def template_pos(pos:Position) = {
-            pos match {
-              case p:OffsetPosition => {
-                val filtered = code.positions.filterKeys( code.positions.ordering.compare(_,p) <= 0 )
-                if( filtered.isEmpty ) {
-                  null
+        // Translate the scala error location info
+        // to the template locations..
+        def template_pos(pos:Position) = {
+          pos match {
+            case p:OffsetPosition => {
+              val filtered = code.positions.filterKeys( code.positions.ordering.compare(_,p) <= 0 )
+              if( filtered.isEmpty ) {
+                null
+              } else {
+                val (key,value) = filtered.last
+                // TODO: handle the case where the line is different too.
+                val colChange = pos.column - key.column
+                if( colChange >=0 ) {
+                  OffsetPosition(value.source, value.offset+colChange)
                 } else {
-                  val (key,value) = filtered.last
-                  // TODO: handle the case where the line is different too.
-                  val colChange = pos.column - key.column
-                  if( colChange >=0 ) {
-                    OffsetPosition(value.source, value.offset+colChange)
-                  } else {
-                    pos
-                  }
+                  pos
                 }
               }
-              case _=> null
             }
+            case _=> null
           }
+        }
 
-          var newmessage = "Compilation failed:\n"
-          val errors = e.errors.map {
-            (olderror) =>
-              val uri = source.uri
-              val pos =  template_pos(olderror.pos)
-              if( pos==null ) {
-                newmessage += ":"+olderror.pos+" "+olderror.message+"\n"
-                newmessage += olderror.pos.longString+"\n"
-                olderror
-              } else {
-                newmessage += uri+":"+pos+" "+olderror.message+"\n"
-                newmessage += pos.longString+"\n"
-                // TODO should we pass the source?
-                CompilerError(uri, olderror.message, pos, olderror)
-              }
-          }
-          error(e)
-          if (e.errors.isEmpty) {
-            throw e
-          }
-          else {
-            throw new CompilerException(newmessage, errors)
-          }
+        var newmessage = "Compilation failed:\n"
+        val errors = e.errors.map {
+          (olderror) =>
+            val uri = source.uri
+            val pos =  template_pos(olderror.pos)
+            if( pos==null ) {
+              newmessage += ":"+olderror.pos+" "+olderror.message+"\n"
+              newmessage += olderror.pos.longString+"\n"
+              olderror
+            } else {
+              newmessage += uri+":"+pos+" "+olderror.message+"\n"
+              newmessage += pos.longString+"\n"
+              // TODO should we pass the source?
+              CompilerError(uri, olderror.message, pos, olderror)
+            }
+        }
+        error(e)
+        if (e.errors.isEmpty) {
+          throw e
+        }
+        else {
+          throw new CompilerException(newmessage, errors)
         }
       case e: InvalidSyntaxException =>
         e.source = source


### PR DESCRIPTION
Currently the code attempts template compilation twice. Unfortunately, the side-effect of this is that not all useful errors are reported during compilation, since only the first compilation reports errors during the early phases of the scala compiler.

For example, if you try to compile a template that refers to a class, which in turn refers to a non-existent annotation class, scala will return a "dependency missing" error (see https://issues.scala-lang.org/browse/SI-5420). The error reported by the compiler the first time is _extremely_ useful in fixing the problem. However, the second time the compiler is called _it does not issue the same error again_ (this may or may not be a bug in scala, but I suspect it is a side-effect of a compiler optimization).

Since scalate always retries the compilation, the useful error from the first attempt is never reported.

The attached patch removes the retry for normal compilation failures throwing CompilerException (but leaves it for the InstantiationException case). I haven't had a problem with this so far but admittedly have not tested this under load.
