### PR TITLE
Have ScalateView properly register its ServletRenderContext objects

### DIFF
--- a/scalate-spring-mvc/src/main/scala/org/fusesource/scalate/spring/view/ScalateView.scala
+++ b/scalate-spring-mvc/src/main/scala/org/fusesource/scalate/spring/view/ScalateView.scala
@@ -21,6 +21,7 @@ import _root_.java.util.Locale
 import _root_.javax.servlet.ServletConfig
 import _root_.javax.servlet.http.HttpServletRequest
 import _root_.javax.servlet.http.HttpServletResponse
+import _root_.org.fusesource.scalate.RenderContext
 import _root_.org.fusesource.scalate.servlet.ServletRenderContext
 import _root_.org.fusesource.scalate.servlet.ServletTemplateEngine
 import _root_.org.springframework.web.context.ServletConfigAware
@@ -81,7 +82,9 @@ class ScalateUrlView extends AbstractTemplateView with AbstractScalateView
                                          response: HttpServletResponse) : Unit = {
 
     val context = new ServletRenderContext(templateEngine, request, response, getServletContext)
-    render(context, model.asInstanceOf[java.util.Map[String,Any]].toMap)
+    RenderContext.using(context) {
+      render(context, model.asInstanceOf[java.util.Map[String,Any]].toMap)
+    }
   }
 
   override def checkResource(locale: Locale): Boolean = try {
@@ -106,7 +109,9 @@ class ScalateView extends AbstractScalateView with ViewScalateRenderStrategy {
                                          response: HttpServletResponse) : Unit = {
 
     val context = new ServletRenderContext(templateEngine, request, response, getServletContext)
-    render(context, model.asInstanceOf[java.util.Map[String,Any]].toMap)
+    RenderContext.using(context) {
+      render(context, model.asInstanceOf[java.util.Map[String,Any]].toMap)
+    }
   }
 
 }


### PR DESCRIPTION
This is a fix for the "This threads RenderContext is not a ServletRenderContext as it is: null" problem mentioned here when using Scalate with Spring MVC: https://groups.google.com/d/msg/scalate/3QqrFeQjf5U/A56HDajo3aoJ

This fix registers the ServletRenderContext objects created in ScalateView so they can be accessed later according to http://scalate.fusesource.org/documentation/user-guide.html#accessing_request_state_inside_a_scala_function
