### PR TITLE
Do not create ServletTemplateEngine for every view, reuse once created o...

### DIFF
--- a/scalate-spring-mvc/src/main/scala/org/fusesource/scalate/spring/view/ScalateView.scala
+++ b/scalate-spring-mvc/src/main/scala/org/fusesource/scalate/spring/view/ScalateView.scala
@@ -27,19 +27,19 @@ import _root_.org.fusesource.scalate.servlet.ServletTemplateEngine
 import _root_.org.springframework.web.context.ServletConfigAware
 import _root_.scala.collection.JavaConversions._
 import _root_.org.fusesource.scalate.TemplateException
-import _root_.org.springframework.web.servlet.view.{AbstractView, AbstractTemplateView}
+import _root_.org.springframework.web.servlet.view.{ AbstractView, AbstractTemplateView }
 import _root_.org.slf4j.LoggerFactory
 import org.fusesource.scalate.util.ResourceNotFoundException
 
 trait ScalateRenderStrategy {
   protected val log = LoggerFactory.getLogger(getClass)
-  def render(context:ServletRenderContext, model: Map[String,Any]);
+  def render(context: ServletRenderContext, model: Map[String, Any]);
 }
 
 trait LayoutScalateRenderStrategy extends AbstractTemplateView with ScalateRenderStrategy {
-  def templateEngine:ServletTemplateEngine
-  def render(context:ServletRenderContext, model: Map[String,Any]) {
-    log.debug("Rendering view with name '"+ getUrl + "' with model " + model)
+  def templateEngine: ServletTemplateEngine
+  def render(context: ServletRenderContext, model: Map[String, Any]) {
+    log.debug("Rendering view with name '" + getUrl + "' with model " + model)
     for ((key, value) <- model) {
       context.attributes(key) = value
     }
@@ -48,15 +48,15 @@ trait LayoutScalateRenderStrategy extends AbstractTemplateView with ScalateRende
 }
 
 trait DefaultScalateRenderStrategy extends AbstractTemplateView with ScalateRenderStrategy {
-  override def render(context:ServletRenderContext, model: Map[String,Any]) {
-    log.debug("Rendering view with name '"+ getUrl + "' with model " + model)
+  override def render(context: ServletRenderContext, model: Map[String, Any]) {
+    log.debug("Rendering view with name '" + getUrl + "' with model " + model)
     context.render(getUrl, model)
   }
 }
 
 trait ViewScalateRenderStrategy extends ScalateRenderStrategy {
-  override def render(context:ServletRenderContext, model: Map[String,Any]) {
-	  log.debug("Rendering with model " + model)
+  override def render(context: ServletRenderContext, model: Map[String, Any]) {
+    log.debug("Rendering with model " + model)
     val it = model.get("it")
     if (it.isEmpty)
       throw new TemplateException("No 'it' model object specified.  Cannot render request")
@@ -64,26 +64,21 @@ trait ViewScalateRenderStrategy extends ScalateRenderStrategy {
   }
 }
 
-
-trait AbstractScalateView extends AbstractView with ServletConfigAware {
-  var templateEngine:ServletTemplateEngine = _;
+trait AbstractScalateView extends AbstractView {
+  var templateEngine: ServletTemplateEngine = _;
   def checkResource(locale: Locale): Boolean;
-
-  override def setServletConfig(config:ServletConfig) {
-    templateEngine = new ServletTemplateEngine(config);
-  }
 }
 
 class ScalateUrlView extends AbstractTemplateView with AbstractScalateView
-        with ServletConfigAware with LayoutScalateRenderStrategy  {
+  with LayoutScalateRenderStrategy {
 
   override def renderMergedTemplateModel(model: java.util.Map[String, Object],
-                                         request: HttpServletRequest,
-                                         response: HttpServletResponse) : Unit = {
+    request: HttpServletRequest,
+    response: HttpServletResponse): Unit = {
 
     val context = new ServletRenderContext(templateEngine, request, response, getServletContext)
     RenderContext.using(context) {
-      render(context, model.asInstanceOf[java.util.Map[String,Any]].toMap)
+      render(context, model.asInstanceOf[java.util.Map[String, Any]].toMap)
     }
   }
 
@@ -93,8 +88,8 @@ class ScalateUrlView extends AbstractTemplateView with AbstractScalateView
     true
   } catch {
     case e: ResourceNotFoundException => {
-    	log.info("Could not find resource " + getUrl);
-    	false
+      log.info("Could not find resource " + getUrl);
+      false
     }
   }
 
@@ -105,12 +100,12 @@ class ScalateView extends AbstractScalateView with ViewScalateRenderStrategy {
   override def checkResource(locale: Locale) = true;
 
   override def renderMergedOutputModel(model: java.util.Map[String, Object],
-                                         request: HttpServletRequest,
-                                         response: HttpServletResponse) : Unit = {
+    request: HttpServletRequest,
+    response: HttpServletResponse): Unit = {
 
     val context = new ServletRenderContext(templateEngine, request, response, getServletContext)
     RenderContext.using(context) {
-      render(context, model.asInstanceOf[java.util.Map[String,Any]].toMap)
+      render(context, model.asInstanceOf[java.util.Map[String, Any]].toMap)
     }
   }
 

--- a/scalate-spring-mvc/src/main/scala/org/fusesource/scalate/spring/view/ScalateViewResolver.scala
+++ b/scalate-spring-mvc/src/main/scala/org/fusesource/scalate/spring/view/ScalateViewResolver.scala
@@ -18,16 +18,28 @@
 package org.fusesource.scalate.spring.view
 
 import java.util.Locale
+
 import org.springframework.web.servlet.View
 import org.springframework.web.servlet.view.AbstractTemplateViewResolver
 import org.springframework.web.servlet.view.AbstractUrlBasedView
+import org.springframework.web.context.ServletConfigAware
+import org.fusesource.scalate.servlet.ServletTemplateEngine
+import javax.servlet.ServletConfig
 
-class ScalateViewResolver() extends AbstractTemplateViewResolver {
+class ScalateViewResolver() extends AbstractTemplateViewResolver with ServletConfigAware {
+
+  var templateEngine: ServletTemplateEngine = _
+
+  override def setServletConfig(config: ServletConfig) {
+    val ste = new ServletTemplateEngine(config)
+    ServletTemplateEngine(config.getServletContext()) = ste
+    templateEngine = ste;
+  }
 
   setViewClass(requiredViewClass())
 
   override def requiredViewClass(): java.lang.Class[_] = classOf[org.fusesource.scalate.spring.view.ScalateView]
-  
+
   override def buildView(viewName: String): AbstractUrlBasedView = {
     var view: AbstractScalateView = null
 
@@ -42,6 +54,8 @@ class ScalateViewResolver() extends AbstractTemplateViewResolver {
       urlView.setUrl(getPrefix() + viewName + getSuffix())
       view = urlView
     }
+
+    view.templateEngine = templateEngine
 
     val contentType = getContentType
     if (contentType != null) {


### PR DESCRIPTION
Keep ServletTemplateEngine in ViewResolver (not View itself).
So it is not created/initialized for every view.

And invoke boot class [reported in Google Groups](https://groups.google.com/forum/?fromgroups=#!searchin/scalate/spring$20layout:/scalate/1MRwOVifiS4/TkhMV5mxrVMJ).
