### PR TITLE
Bump to Scala 2.10.0-SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,12 @@
 
     <osgi-version>4.2.0</osgi-version>
 
-    <scala-version>2.10.0-RC1</scala-version>
+    <scala-version>2.10.0-SNAPSHOT</scala-version>
     <!--
     <scala-version>2.8.1</scala-version>
     -->
 
-    <scalatest-artifact>scalatest_${scala-version}</scalatest-artifact>
+    <scalatest-artifact>scalatest_2.10.0-RC1</scalatest-artifact>
     <scalatest-version>1.8</scalatest-version>
 
     <sbt-version>0.7.3</sbt-version>


### PR DESCRIPTION
Gets the fix to https://issues.scala-lang.org/browse/SI-6556, which was
causing the compiler to crash on LoopTest.

Requires scala-mojo-support for the same version.  I ran `mvn:install` on rossabaker/mvnplugins@https://github.com/rossabaker/mvnplugins/tree/74e8afbea0b4584d1431c5589144b6a82402568f.  We still need to get that dependency sorted out, but that's a separate issue.

Do we need to work around the compiler crash for RC1, or is everyone comfortable moving to SNAPSHOT until RC2?
