### PR TITLE
Move addon filters into their own subpackages

### DIFF
--- a/scalate-less/src/main/scala/org/fusesource/scalate/filter/less/LessFilter.scala
+++ b/scalate-less/src/main/scala/org/fusesource/scalate/filter/less/LessFilter.scala
@@ -15,10 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.scalate.filter
+package org.fusesource.scalate.filter.less
 
 import org.fusesource.scalate.{TemplateEngineAddOn, RenderContext, TemplateEngine}
 import com.asual.lesscss.LessEngine
+import org.fusesource.scalate.filter.Filter
 
 /**
  * Renders Less syntax.

--- a/scalate-markdownj/src/main/scala/org/fusesource/scalate/filter/markdownj/MarkdownJFilter.scala
+++ b/scalate-markdownj/src/main/scala/org/fusesource/scalate/filter/markdownj/MarkdownJFilter.scala
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.scalate.filter
+package org.fusesource.scalate.filter.markdownj
 
 /**
  * Copyright (C) 2009-2010 the original author or authors.
@@ -36,6 +36,7 @@ package org.fusesource.scalate.filter
  */
 import com.petebevin.markdown.MarkdownProcessor
 import org.fusesource.scalate.{RenderContext, TemplateEngine, TemplateEngineAddOn}
+import org.fusesource.scalate.filter.Filter
 
 /**
  * Renders markdown syntax.

--- a/scalate-pegdown/src/main/scala/org/fusesource/scalate/filter/pegdown/PegDownFilter.scala
+++ b/scalate-pegdown/src/main/scala/org/fusesource/scalate/filter/pegdown/PegDownFilter.scala
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fusesource.scalate.filter
+package org.fusesource.scalate.filter.pegdown
 
 import org.fusesource.scalate.{TemplateEngineAddOn, RenderContext, TemplateEngine}
 import org.fusesource.scalate.filter.Filter


### PR DESCRIPTION
Addon filters moved into their own subpackages. This keeps things clean
and prevents a "split package" situation with OSGi deployments.
