### PR TITLE
Applications should never catch subclasses of java.lang.Error

### DIFF
--- a/scalate-test/src/main/scala/org/fusesource/scalate/test/WebDriverMixin.scala
+++ b/scalate-test/src/main/scala/org/fusesource/scalate/test/WebDriverMixin.scala
@@ -124,7 +124,7 @@ trait WebDriverMixin extends BeforeAndAfterAll {
       answer
     }
     catch {
-      case e => println("Failed to find xpath: " + selector + " on page due to: " + e)
+      case e: Exception => println("Failed to find xpath: " + selector + " on page due to: " + e)
       println(pageSource)
       throw e
     }

--- a/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/PygmentsBlock.scala
+++ b/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/PygmentsBlock.scala
@@ -71,7 +71,7 @@ object Pygmentize extends Log with Filter with TemplateEngineAddOn {
       }
     }
     catch {
-      case e => debug(e, "Failed to start pygmetize: " + e)
+      case e: Exception => debug(e, "Failed to start pygmetize: " + e)
       false
     }
   }

--- a/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/Snippets.scala
+++ b/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/Snippets.scala
@@ -139,7 +139,7 @@ class SnippetBlock extends ParameterizedBlock {
       }
     }
     catch {
-      case e => Snippets.errorHandler(this, e)
+      case e: Exception => Snippets.errorHandler(this, e)
     }
     handler.done
     


### PR DESCRIPTION
A followup to https://github.com/scalate/scalate/pull/29
