### PR TITLE
SIP-18: enable feature warnings, explicitly import advanced language features

### DIFF
--- a/maven-scalate-plugin/src/main/java/org/fusesource/scalate/maven/ConfExportMojoSupport.scala
+++ b/maven-scalate-plugin/src/main/java/org/fusesource/scalate/maven/ConfExportMojoSupport.scala
@@ -43,7 +43,8 @@ class ConfExportMojoSupport {
     val oldLoader = Thread.currentThread.getContextClassLoader
     Thread.currentThread.setContextClassLoader(loader)
     try {
-      
+      import scala.language.reflectiveCalls      
+
       // Structural Typing FTW (avoids us doing manual reflection)
       type ConfluenceExport = {
         var url: String

--- a/maven-scalate-plugin/src/main/java/org/fusesource/scalate/maven/PrecompileMojoSupport.scala
+++ b/maven-scalate-plugin/src/main/java/org/fusesource/scalate/maven/PrecompileMojoSupport.scala
@@ -48,6 +48,8 @@ class PrecompileMojoSupport {
     val oldLoader = Thread.currentThread.getContextClassLoader
     Thread.currentThread.setContextClassLoader(loader)
     try {
+      import scala.language.reflectiveCalls
+
       // Structural Typing FTW (avoids us doing manual reflection)
       type Precompiler = {
         var sources: Array[File]

--- a/maven-scalate-plugin/src/main/java/org/fusesource/scalate/maven/SiteGenNoForkMojoSupport.scala
+++ b/maven-scalate-plugin/src/main/java/org/fusesource/scalate/maven/SiteGenNoForkMojoSupport.scala
@@ -50,6 +50,7 @@ class SiteGenNoForkMojoSupport {
     val oldLoader = Thread.currentThread.getContextClassLoader
     Thread.currentThread.setContextClassLoader(loader)
     try {
+      import scala.language.reflectiveCalls
       
       // Structural Typing FTW (avoids us doing manual reflection)
       type SiteGenerator = {

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,7 @@
             <args>
               <!-- arg>-unchecked</arg -->
               <arg>-deprecation</arg>
+              <arg>-feature</arg>
             </args>
             <scalaVersion>${scala-version}</scalaVersion>
             <recompileMode>incremental</recompileMode>

--- a/scalate-core/src/main/scala/org/fusesource/scalate/RenderContext.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/RenderContext.scala
@@ -63,6 +63,8 @@ object RenderContext {
  * @see org.fusesource.scalate.servlet.ServletRenderContext
  */
 trait RenderContext {
+  import scala.language.implicitConversions
+  
   /**
    * Default string used to output null values
    */

--- a/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
@@ -881,6 +881,8 @@ class TemplateEngine(var sourceDirectories: Traversable[File] = None, var mode: 
   }
 
   private def loadCompiledTemplate(className:String, from_cache:Boolean=true):Template = {
+    import scala.language.existentials
+    
     val cl = if(from_cache) {
       new URLClassLoader(Array(bytecodeDirectory.toURI.toURL), classLoader)
     } else {

--- a/scalate-core/src/main/scala/org/fusesource/scalate/mustache/MustacheCodeGenerator.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/mustache/MustacheCodeGenerator.scala
@@ -30,6 +30,7 @@ object MustacheCodeGenerator extends Log
  */
 class MustacheCodeGenerator extends AbstractCodeGenerator[Statement] {
   import MustacheCodeGenerator._
+  import scala.language.implicitConversions
 
   override val stratumName = "MSC"
 

--- a/scalate-core/src/main/scala/org/fusesource/scalate/scaml/ScamlCodeGenerator.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/scaml/ScamlCodeGenerator.scala
@@ -30,6 +30,8 @@ import scala.util.parsing.input.OffsetPosition
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 class ScamlCodeGenerator extends AbstractCodeGenerator[Statement] {
+  import scala.language.implicitConversions
+  
   override val stratumName = "SCAML"
 
   implicit def textToString(text: Text) = text.value

--- a/scalate-core/src/main/scala/org/fusesource/scalate/scuery/ScueryConversions.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/scuery/ScueryConversions.scala
@@ -23,6 +23,8 @@ import xml.{Node, NodeSeq}
  * All the various implicit conversions for the scuery package
  */
 trait ScueryConversions {
+  import scala.language.implicitConversions
+  
   implicit def toNodes(transform: Transform): NodeSeq = transform()
 
   implicit def toSXml(node: Node) = SXml(node)

--- a/scalate-core/src/main/scala/org/fusesource/scalate/scuery/Transform.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/scuery/Transform.scala
@@ -20,6 +20,8 @@ package org.fusesource.scalate.scuery
 import xml.{Attribute, Document, Elem, Node, NodeSeq, Null, Text}
 
 object Transform {
+  import scala.language.implicitConversions
+  
   implicit def toNodes(transform: Transform): NodeSeq = transform()
   implicit def toTraversable(transform: Transform): Traversable[Node] = transform()
 }

--- a/scalate-core/src/main/scala/org/fusesource/scalate/scuery/Transformer.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/scuery/Transformer.scala
@@ -29,6 +29,8 @@ import XmlHelper._
  * @version $Revision : 1.1 $
  */
 class Transformer {
+  import scala.language.implicitConversions
+  
   protected val _rules = new HashMap[Selector, Rule]
 
   implicit def toSXml(node: Node) = SXml(node)

--- a/scalate-core/src/main/scala/org/fusesource/scalate/servlet/Config.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/servlet/Config.scala
@@ -21,6 +21,8 @@ import java.util.Enumeration
 import javax.servlet.{FilterConfig, ServletContext, ServletConfig}
 
 object Config {
+  import scala.language.implicitConversions
+  
   implicit def servletConfig2Config(servletConfig: ServletConfig) = new Config {
     def getName = servletConfig.getServletName
     def getServletContext = servletConfig.getServletContext

--- a/scalate-core/src/main/scala/org/fusesource/scalate/ssp/SspCodeGenerator.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/ssp/SspCodeGenerator.scala
@@ -22,6 +22,8 @@ import collection.mutable.Stack
 import support.{Text, Code, AbstractCodeGenerator}
 
 class SspCodeGenerator extends AbstractCodeGenerator[PageFragment] {
+  import scala.language.implicitConversions
+  
   override val stratumName = "SSP"
 
   implicit def textToString(text: Text) = text.value

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/AbstractCodeGenerator.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/AbstractCodeGenerator.scala
@@ -98,6 +98,7 @@ abstract class AbstractCodeGenerator[T] extends CodeGenerator
     def indent[T](op: => T): T = {indentLevel += 1; val rc = op; indentLevel -= 1; rc}
 
     def generate(engine: TemplateEngine, source: TemplateSource, bindings: Traversable[Binding], statements: List[T]): Unit = {
+      import scala.language.postfixOps
 
       val packageName = source.packageName
       val className = source.simpleClassName
@@ -199,6 +200,8 @@ abstract class AbstractCodeGenerator[T] extends CodeGenerator
     }
 
     protected def generateTemplatePackage(source: TemplateSource, bindings: Traversable[Binding]): Unit = {
+      import scala.language.postfixOps
+      
       val templatePackage = TemplatePackage.findTemplatePackage(source).getOrElse(new DefaultTemplatePackage())
       this << templatePackage.header(source, bindings.toList)
       this <<;

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/Boots.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/Boots.scala
@@ -11,6 +11,8 @@ import util.Objects
 object Boots {
 
   def invokeBoot(clazz: Class[_], injectionParameters: List[AnyRef]): Unit = {
+    import scala.language.reflectiveCalls
+    
     // Structural Typing to make Reflection easier.
     type Boot = {
       def run: Unit

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/Precompiler.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/Precompiler.scala
@@ -41,6 +41,7 @@ class Precompiler {
   var bootClassName:String = _
 
   def execute() = {
+    import scala.language.reflectiveCalls
 
     if(sources==null || sources.isEmpty ) {
       throw new IllegalArgumentException("The sources property not properly set")

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/ScalaCompiler.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/ScalaCompiler.scala
@@ -37,6 +37,8 @@ import util.{Log, IOUtil, ClassPathBuilder}
 object ScalaCompiler extends Log {
 
   def create(engine: TemplateEngine) : ScalaCompiler = {
+    import scala.language.reflectiveCalls
+    
     Thread.currentThread.getContextClassLoader match {
       case BundleClassLoader(loader) => new OsgiScalaCompiler(engine, loader.getBundle)
       case _ => new ScalaCompiler(engine.bytecodeDirectory, engine.classpath, engine.combinedClassPath)

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/ScalaParseSupport.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/ScalaParseSupport.scala
@@ -53,6 +53,7 @@ case class Text(value: String) extends Positional {
  * @version $Revision : 1.1 $
  */
 trait ScalaParseSupport extends RegexParsers {
+  import scala.language.postfixOps
 
   val scalaTypeChar = """a-zA-Z0-9\$_\[\]\.\(\)\#\:\<\>\+\-"""
   val scalaType = ("[" + scalaTypeChar + """]+([ \t\,]+[""" + scalaTypeChar + """]+)*""").r

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/SiteGenerator.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/SiteGenerator.scala
@@ -45,6 +45,8 @@ class SiteGenerator {
 
 
   def execute() = {
+    import scala.language.reflectiveCalls
+
     targetDirectory.mkdirs();
 
     if (webappDirectory == null || !webappDirectory.exists) {

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/TemplateConversions.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/TemplateConversions.scala
@@ -23,8 +23,9 @@ import org.fusesource.scalate.util.Log
  * A number of helper implicit conversions for use in templates
  */
 object TemplateConversions {
-  val log = Log(getClass); import log._
+  import scala.language.implicitConversions
 
+  val log = Log(getClass); import log._
 
   /**
    * Provide access to the elvis operator so that we can use it to provide null handling nicely

--- a/scalate-core/src/test/scala/org/fusesource/scalate/mustache/MustacheParserTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/mustache/MustacheParserTest.scala
@@ -26,6 +26,7 @@ import java.io.File
  */
 
 class MustacheParserTest extends FunSuiteSupport {
+  import scala.language.implicitConversions
 
   implicit def stringToText(x: String) = Text(x)
 

--- a/scalate-core/src/test/scala/org/fusesource/scalate/ssp/ParserTestSupport.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/ssp/ParserTestSupport.scala
@@ -25,6 +25,7 @@ import org.fusesource.scalate.support.Text
  * @version $Revision : 1.1 $
  */
 abstract class ParserTestSupport extends FunSuiteSupport {
+  import scala.language.implicitConversions
 
   implicit def stringToText(x: String) = Text(x)
 

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassLoaders.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassLoaders.scala
@@ -35,6 +35,8 @@ object ClassLoaders {
    * Tries to load the named class on the given class loaders
    */
   def findClass(className: String, classLoaders: Traversable[ClassLoader] = defaultClassLoaders): Option[Class[_]] = {
+	import scala.language.existentials
+
     def tryLoadClass(classLoader: ClassLoader) = {
       try {
         Some(classLoader.loadClass(className))

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassPathBuilder.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassPathBuilder.scala
@@ -135,7 +135,6 @@ private object ClassPathBuilder extends Log {
   }
   
   def getClassPathFrom(classLoader: ClassLoader): Seq[String] = classLoader match {
-    
     case null => Nil
     
     case cl: URLClassLoader =>
@@ -150,6 +149,7 @@ private object ClassPathBuilder extends Log {
       }
 
     case AntLikeClassLoader(acp) =>
+      import scala.language.reflectiveCalls
       val cp = acp.getClasspath
       cp.split(File.pathSeparator)
 

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/IOUtil.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/IOUtil.scala
@@ -23,6 +23,7 @@ import java.util.zip.{ZipEntry, ZipInputStream}
 import java.net.URL
 
 object IOUtil {
+  import scala.language.implicitConversions
 
   val log = Log(getClass); import log._
 

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/SourceMap.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/SourceMap.scala
@@ -463,6 +463,7 @@ object SourceMapInstaller {
     }    
     
     def store: Array[Byte] = {
+      import scala.language.reflectiveCalls
       copy(4 + 2 + 2)
       var constantPoolCountPos: Int = baos.position
       var constantPoolCount: Int = copyShort


### PR DESCRIPTION
features are imported the innermost scope that needs them. I thought it's closer to the SIP-18 spirit than importing them at the top of the source file. If you prefer to keep the imports at the top, I'll redo the change.
If there are no objections I'll merge this PR tomorrow.
