### PR TITLE
use zinc server for incremental compilation when available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,7 @@
             </args>
             <scalaVersion>${scala-version}</scalaVersion>
             <recompileMode>incremental</recompileMode>
+            <useZincServer>true</useZincServer>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
I've tried zinc 0.1.4 today and it really blew my socks off: `mvn clean test-compile` on whole scalate projects takes 5:45 on my machine, but only 2:25 on first compilation with zinc and 1:15 on second and further compilations. 
AFAICT it's safe to turn zinc on for everyone. If there's no daemon available scalate-maven-plugin just prints a warning and uses regular scalac.
If there are no objections I'll merge the PR tomorrow.
