### PR TITLE
Use RenderContext instead of DefaultRenderContext

### DIFF
--- a/scalate-core/src/main/scala/org/fusesource/scalate/console/ConsoleHelper.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/console/ConsoleHelper.scala
@@ -19,7 +19,7 @@ package org.fusesource.scalate.console
 
 import _root_.java.util.regex.Pattern
 import _root_.javax.servlet.ServletContext
-import _root_.org.fusesource.scalate.{DefaultRenderContext, RenderContext}
+import _root_.org.fusesource.scalate.RenderContext
 import _root_.org.fusesource.scalate.servlet.ServletRenderContext
 import _root_.scala.Option
 import java.io.File
@@ -63,7 +63,7 @@ object ConsoleHelper extends Log
  *
  * @version $Revision : 1.1 $
  */
-class ConsoleHelper(context: DefaultRenderContext) extends ConsoleSnippets {
+class ConsoleHelper(context: RenderContext) extends ConsoleSnippets {
   import ConsoleHelper._
   import context._
 

--- a/scalate-core/src/main/scala/org/fusesource/scalate/console/ConsoleSnippets.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/console/ConsoleSnippets.scala
@@ -19,7 +19,7 @@ package org.fusesource.scalate.console
 
 import _root_.javax.servlet.ServletContext
 import _root_.org.fusesource.scalate.servlet.{ServletResourceLoader, ServletRenderContext}
-import _root_.org.fusesource.scalate.DefaultRenderContext
+import _root_.org.fusesource.scalate.RenderContext
 import java.io.File
 import scala.xml.NodeSeq
 
@@ -29,7 +29,7 @@ import scala.xml.NodeSeq
 trait ConsoleSnippets {
   def servletContext: ServletContext
 
-  def renderContext: DefaultRenderContext
+  def renderContext: RenderContext
 
 
   def realPath(uri: String) = ServletResourceLoader(servletContext).realPath(uri)


### PR DESCRIPTION
The code doesn't rely on the context being a DefaultRenderContext, and this causes problems when Scalatra renders Scalate's 500.scaml page since the static type of the context that gets passed to ConsoleHelper is RenderContext.
