### PR TITLE
Update GH page for Scalate 1.7.0

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -30,7 +30,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>
@@ -83,7 +83,7 @@
   </a>
   <div class="details">Posted by James Strachan on Saturday, December 29, 2012</div>
 <p>The <a href="http://scalate.github.io/scalate">Scalate team</a> is pleased to announce the
-availability of Scalate 1.6.1</p>
+availability of Scalate 1.7.0</p>
 
 <p>Scalate is a <a href="http://scalate.github.io/scalate/documentation/jog.html">Scala 2.9 and 2.10] (http://www.scala-lang.org) based <a
 href="http://en.wikipedia.org/wiki/Template&#95;engine&#95;(web)">template

--- a/building.html
+++ b/building.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/camel.html
+++ b/camel.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/code-in-view.html
+++ b/code-in-view.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/committers/release-guide.html
+++ b/committers/release-guide.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/community.html
+++ b/community.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/compare-jsp.html
+++ b/compare-jsp.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/contributing.html
+++ b/contributing.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/creating-ide.html
+++ b/creating-ide.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/developers.html
+++ b/developers.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/documentation/archetypes.html
+++ b/documentation/archetypes.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/console.html
+++ b/documentation/console.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/frameworks.html
+++ b/documentation/frameworks.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/getting-started.html
+++ b/documentation/getting-started.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/htmlConvert.html
+++ b/documentation/htmlConvert.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/installing.html
+++ b/documentation/installing.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/jade-syntax.html
+++ b/documentation/jade-syntax.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/jade.html
+++ b/documentation/jade.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/jog.html
+++ b/documentation/jog.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/jspConvert.html
+++ b/documentation/jspConvert.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/lift.html
+++ b/documentation/lift.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/manual/book.html
+++ b/documentation/manual/book.html
@@ -29,7 +29,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../../index.html">Scalate 1.6.1</a></li>
+<li><a href="../../index.html">Scalate 1.7.0</a></li>
 <li><a href="../../download.html">Download</a></li>
 <li><a href="../../source.html">Source</a></li>
 <li><a href="../../community.html">Community</a></li>

--- a/documentation/mustache.html
+++ b/documentation/mustache.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/osgi.html
+++ b/documentation/osgi.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/scalate-embedding-guide.html
+++ b/documentation/scalate-embedding-guide.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/scalatra.html
+++ b/documentation/scalatra.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/scaml-reference.html
+++ b/documentation/scaml-reference.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/scuery.html
+++ b/documentation/scuery.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/siteGen.html
+++ b/documentation/siteGen.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/spring-mvc.html
+++ b/documentation/spring-mvc.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/ssp-reference.html
+++ b/documentation/ssp-reference.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/tool.html
+++ b/documentation/tool.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/user-guide.html
+++ b/documentation/user-guide.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/documentation/war-overlay.html
+++ b/documentation/war-overlay.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="../index.html">Scalate 1.6.1</a></li>
+<li><a href="../index.html">Scalate 1.7.0</a></li>
 <li><a href="../download.html">Download</a></li>
 <li><a href="../source.html">Source</a></li>
 <li><a href="../community.html">Community</a></li>

--- a/download.html
+++ b/download.html
@@ -41,7 +41,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>
@@ -87,331 +87,34 @@
   <h1 id = "Download">Download</h1>
 </div>
 <div class="right">
-  <p>You can download <strong>Scalate</strong> from the <a href="http://repo.fusesource.com/nexus/content/repositories/public/">Maven Repository</a> in the <a href="http://repo.fusesource.com/nexus/content/repositories/public/org/fusesource/scalate/">Scalate area</a>.</p>
-
-  <p>Download a distribution:</p>
-  <h3>Scalate 1.6.1</h3>
-  <table class="download">
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro_2.10/1.6.1/scalate-distro_2.10-1.6.1-unix-bin.tar.gz">scalate-distro_2.10-1.6.1-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro_2.10/1.6.1/scalate-distro_2.10-1.6.1-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro_2.10/1.6.1/scalate-distro_2.10-1.6.1-windows-bin.zip">scalate-distro_2.10-1.6.1-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro_2.10/1.6.1/scalate-distro_2.10-1.6.1-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-  </table>
-  <div></div>
-  <h3 class="accordion"><a href="#">Older Versions</a></h3>
-  <table class="download hide">
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.3/scalate-distro-1.5.3-unix-bin.tar.gz">scalate-distro-1.5.3-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.3/scalate-distro-1.5.3-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.3/scalate-distro-1.5.3-windows-bin.zip">scalate-distro-1.5.3-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.3/scalate-distro-1.5.3-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.2/scalate-distro-1.5.2-unix-bin.tar.gz">scalate-distro-1.5.2-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.2/scalate-distro-1.5.2-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.2/scalate-distro-1.5.2-windows-bin.zip">scalate-distro-1.5.2-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.2/scalate-distro-1.5.2-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.1/scalate-distro-1.5.1-unix-bin.tar.gz">scalate-distro-1.5.1-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.1/scalate-distro-1.5.1-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.1/scalate-distro-1.5.1-windows-bin.zip">scalate-distro-1.5.1-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.1/scalate-distro-1.5.1-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.0/scalate-distro-1.5.0-unix-bin.tar.gz">scalate-distro-1.5.0-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.0/scalate-distro-1.5.0-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.0/scalate-distro-1.5.0-windows-bin.zip">scalate-distro-1.5.0-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.5.0/scalate-distro-1.5.0-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.4.1/scalate-distro-1.4.1-unix-bin.tar.gz">scalate-distro-1.4.1-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.4.1/scalate-distro-1.4.1-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.4.1/scalate-distro-1.4.1-windows-bin.zip">scalate-distro-1.4.1-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.4.1/scalate-distro-1.4.1-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.4.0/scalate-distro-1.4.0-unix-bin.tar.gz">scalate-distro-1.4.0-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.4.0/scalate-distro-1.4.0-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.4.0/scalate-distro-1.4.0-windows-bin.zip">scalate-distro-1.4.0-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.4.0/scalate-distro-1.4.0-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3.2/scalate-distro-1.3.2-unix-bin.tar.gz">scalate-distro-1.3.2-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3.2/scalate-distro-1.3.2-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3.2/scalate-distro-1.3.2-windows-bin.zip">scalate-distro-1.3.2-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3.2/scalate-distro-1.3.2-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3.1/scalate-distro-1.3.1-unix-bin.tar.gz">scalate-distro-1.3.1-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3.1/scalate-distro-1.3.1-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3.1/scalate-distro-1.3.1-windows-bin.zip">scalate-distro-1.3.1-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3.1/scalate-distro-1.3.1-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3/scalate-distro-1.3-unix-bin.tar.gz">scalate-distro-1.3-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3/scalate-distro-1.3-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3/scalate-distro-1.3-windows-bin.zip">scalate-distro-1.3-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.3/scalate-distro-1.3-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.2/scalate-distro-1.2-unix-bin.tar.gz">scalate-distro-1.2-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.2/scalate-distro-1.2-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.2/scalate-distro-1.2-windows-bin.zip">scalate-distro-1.2-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.2/scalate-distro-1.2-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.1/scalate-distro-1.1-unix-bin.tar.gz">scalate-distro-1.1-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.1/scalate-distro-1.1-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.1/scalate-distro-1.1-windows-bin.zip">scalate-distro-1.1-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.1/scalate-distro-1.1-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Unix:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.0/scalate-distro-1.0-unix-bin.tar.gz">scalate-distro-1.0-unix-bin.tar.gz</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.0/scalate-distro-1.0-unix-bin.tar.gz.asc">GPG</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Windows:
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.0/scalate-distro-1.0-windows-bin.zip">scalate-distro-1.0-windows-bin.zip</a>
-      </td>
-      <td>
-        <a href="http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/scalate/scalate-distro/1.0/scalate-distro-1.0-windows-bin.zip.asc">GPG</a>
-      </td>
-    </tr>
-  </table>
-  <p>You can now <a href="documentation/tool.html">install the Scalate Tool</a></p>
-
-  <h2 id = "Snapshots">Snapshots</h2>
-
-  <p>You can download a recent snapshot from the <a href="http://repo.fusesource.com/nexus/content/repositories/snapshots/">Snapshot Maven Repository</a> in the <a href="http://repo.fusesource.com/nexus/content/repositories/snapshots/org/fusesource/scalate/">Scalate area</a>.</p>
-
-  <ul>
-  <li><a href="http://repo.fusesource.com/nexus/service/local/artifact/maven/redirect?r=snapshots&amp;g=org.fusesource.scalate&amp;a=scalate-distro&#95;2.10&amp;v=1.7.0-SNAPSHOT&amp;e=zip&amp;c=windows-bin">1.7.0-SNAPSHOT zip</a> or <a href="http://repo.fusesource.com/nexus/service/local/artifact/maven/redirect?r=snapshots&amp;g=org.fusesource.scalate&amp;a=scalate-distro&#95;2.10&amp;v=1.7.0-SNAPSHOT&amp;e=tar.gz&amp;c=unix-bin">tar.gz</a></li>
-  </ul>
+  <p>You can download <strong>Scalate</strong> from the <a href="https://oss.sonatype.org/content/repositories/releases/org/scalatra/scalate/">Sonatype repository</a>.</p>
 </div>
-<div class="left">
-  <h1 id = "Maven">Maven</h1>
+<div class="right">
+  <h1 id="sbt">sbt</h1>
+  <p>If you build your project using <a href="http://www.scala-sbt.org/">sbt</a> then just add the following to your <em>build.sbt</em> or <em>project/Build.scala</em></p>
+
+  <div class="syntax"><div class="highlight">
+  <pre><span class="nt">libraryDependencies += 
+  "org.scalatra.scalate" %% "scalate-core" % "1.7.0"</pre></div>&#x000A;</div>
+
+</div>
+<div class="right">
+  <h1 id="Maven">Maven</h1>
 </div>
 <div class="right">
   <p>If you build your project using <a href="http://maven.apache.org/">Maven</a> then just add the following to your <em>pom.xml</em></p>
 
-  <div class="syntax"><div class="highlight"><pre><span class="nt">&lt;dependency&gt;</span>&#x000A;  <span class="nt">&lt;groupId&gt;</span>org.fusesource.scalate<span class="nt">&lt;/groupId&gt;</span>&#x000A;  <span class="nt">&lt;artifactId&gt;</span>scalate-core_2.10<span class="nt">&lt;/artifactId&gt;</span>&#x000A;  <span class="nt">&lt;version&gt;</span>1.6.1<span class="nt">&lt;/version&gt;</span>  &#x000A;<span class="nt">&lt;/dependency&gt;</span>&#x000A;</pre></div>&#x000A;</div>
+  <div class="syntax"><div class="highlight"><pre><span class="nt">&lt;dependency&gt;</span>&#x000A;  <span class="nt">&lt;groupId&gt;</span>org.scalatra.scalate<span class="nt">&lt;/groupId&gt;</span>&#x000A;  <span class="nt">&lt;artifactId&gt;</span>scalate-core_2.11<span class="nt">&lt;/artifactId&gt;</span>&#x000A;  <span class="nt">&lt;version&gt;</span>1.7.0<span class="nt">&lt;/version&gt;</span>  &#x000A;<span class="nt">&lt;/dependency&gt;</span>&#x000A;</pre></div>&#x000A;</div>
 
-  <p>The releases should be synchronized to the <a href="http://repo1.maven.org/maven2/org/fusesource/scalate/">central maven repository</a> so you should not need to add a maven repository to your pom.xml. </p>
+  <p>The releases should be synchronized to the <a href="http://repo1.maven.org/maven2/org/scalatra/scalate/">central maven repository</a> so you should not need to add a maven repository to your pom.xml. </p>
 
   <p>However if a release has not yet made it to the central repository or you want to add a repository for completeness, add the following to your <em>pom.xml</em></p>
-
-  <div class="syntax"><div class="highlight"><pre>  &#x000A;<span class="nt">&lt;repositories&gt;</span>&#x000A;   <span class="nt">&lt;repository&gt;</span>&#x000A;     <span class="nt">&lt;id&gt;</span>fusesource.m2<span class="nt">&lt;/id&gt;</span>&#x000A;     <span class="nt">&lt;name&gt;</span>FuseSource Public Repository<span class="nt">&lt;/name&gt;</span>&#x000A;     <span class="nt">&lt;url&gt;</span>http://repo.fusesource.com/nexus/content/repositories/public<span class="nt">&lt;/url&gt;</span>&#x000A;     <span class="nt">&lt;snapshots&gt;</span>&#x000A;       <span class="nt">&lt;enabled&gt;</span>false<span class="nt">&lt;/enabled&gt;</span>&#x000A;     <span class="nt">&lt;/snapshots&gt;</span>&#x000A;     <span class="nt">&lt;releases&gt;</span>&#x000A;       <span class="nt">&lt;enabled&gt;</span>true<span class="nt">&lt;/enabled&gt;</span>&#x000A;     <span class="nt">&lt;/releases&gt;</span>&#x000A;   <span class="nt">&lt;/repository&gt;</span>&#x000A; <span class="nt">&lt;/repositories&gt;</span>&#x000A;</pre></div>&#x000A;</div>
 
   <h2 id = "Snapshots">Snapshots</h2>
 
   <p>If you want to use a <strong>snapshot version</strong> you should ensure you have the Scalate Snapshot Maven repository defined in your <em>pom.xml</em></p>
 
-  <div class="syntax"><div class="highlight"><pre>  &#x000A;<span class="nt">&lt;repositories&gt;</span>&#x000A;   <span class="nt">&lt;repository&gt;</span>&#x000A;     <span class="nt">&lt;id&gt;</span>fusesource.snapshots<span class="nt">&lt;/id&gt;</span>&#x000A;     <span class="nt">&lt;name&gt;</span>FuseSource Snapshot Repository<span class="nt">&lt;/name&gt;</span>&#x000A;     <span class="nt">&lt;url&gt;</span>http://repo.fusesource.com/nexus/content/repositories/snapshots<span class="nt">&lt;/url&gt;</span>&#x000A;     <span class="nt">&lt;snapshots&gt;</span>&#x000A;       <span class="nt">&lt;enabled&gt;</span>true<span class="nt">&lt;/enabled&gt;</span>&#x000A;     <span class="nt">&lt;/snapshots&gt;</span>&#x000A;     <span class="nt">&lt;releases&gt;</span>&#x000A;       <span class="nt">&lt;enabled&gt;</span>false<span class="nt">&lt;/enabled&gt;</span>&#x000A;     <span class="nt">&lt;/releases&gt;</span>&#x000A;   <span class="nt">&lt;/repository&gt;</span>&#x000A; <span class="nt">&lt;/repositories&gt;</span>&#x000A;</pre></div>&#x000A;</div>
+  <div class="syntax"><div class="highlight"><pre>  &#x000A;<span class="nt">&lt;repositories&gt;</span>&#x000A;   <span class="nt">&lt;repository&gt;</span>&#x000A;     <span class="nt">&lt;id&gt;</span>sonatype snapshots<span class="nt">&lt;/id&gt;</span>&#x000A;     <span class="nt">&lt;name&gt;</span>Sonatype Snapshot Repository<span class="nt">&lt;/name&gt;</span>&#x000A;     <span class="nt">&lt;url&gt;</span>https://oss.sonatype.org/content/repositories/snapshots<span class="nt">&lt;/url&gt;</span>&#x000A;     <span class="nt">&lt;snapshots&gt;</span>&#x000A;       <span class="nt">&lt;enabled&gt;</span>true<span class="nt">&lt;/enabled&gt;</span>&#x000A;     <span class="nt">&lt;/snapshots&gt;</span>&#x000A;     <span class="nt">&lt;releases&gt;</span>&#x000A;       <span class="nt">&lt;enabled&gt;</span>false<span class="nt">&lt;/enabled&gt;</span>&#x000A;     <span class="nt">&lt;/releases&gt;</span>&#x000A;   <span class="nt">&lt;/repository&gt;</span>&#x000A; <span class="nt">&lt;/repositories&gt;</span>&#x000A;</pre></div>&#x000A;</div>
 </div>
 <div class="left">
   <h1 id = "Building">Building</h1>

--- a/faq.html
+++ b/faq.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>
@@ -63,7 +63,7 @@
           <img src="images/project-logo.png" alt="Scalate logo"/>
         </div>
         <div class="message">
-<h1>Scalate 1.6.1</h1>
+<h1>Scalate 1.7.0</h1>
 Scala Template Engine: like JSP without the crap but with added Scala coolness
 
           <div></div>
@@ -74,7 +74,7 @@ Scala Template Engine: like JSP without the crap but with added Scala coolness
       <div class="wrapper">
 <h1 id = "Scalate:_Scala_Template_Engine">Scalate: Scala Template Engine</h1>
 
-<p>Scalate is a <a href="http://www.scala-lang.org">Scala 2.9 and 2.10</a> based <a href="http://en.wikipedia.org/wiki/Template&#95;engine&#95;(web)">template engine</a> for generating text and markup which can be used in the following <a href="documentation/frameworks.html">frameworks</a> and environments:</p>
+<p>Scalate is a <a href="http://www.scala-lang.org">Scala 2.10 and 2.11</a> based <a href="http://en.wikipedia.org/wiki/Template&#95;engine&#95;(web)">template engine</a> for generating text and markup which can be used in the following <a href="documentation/frameworks.html">frameworks</a> and environments:</p>
 
 <ul>
 <li>stand alone in any JVM or as a <a href="documentation/user-guide.html#using&#95;scalate&#95;as&#95;servlet&#95;filter&#95;in&#95;your&#95;web&#95;application">Servlet Filter</a> in any Java in a web application</li>

--- a/jrebel.html
+++ b/jrebel.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/sbt.html
+++ b/sbt.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/site.html
+++ b/site.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/source.html
+++ b/source.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/support.html
+++ b/support.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/which.html
+++ b/which.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>

--- a/why.html
+++ b/why.html
@@ -27,7 +27,7 @@
       </div>
       <div class="wrapper">
 <ul>
-<li><a href="index.html">Scalate 1.6.1</a></li>
+<li><a href="index.html">Scalate 1.7.0</a></li>
 <li><a href="download.html">Download</a></li>
 <li><a href="source.html">Source</a></li>
 <li><a href="community.html">Community</a></li>


### PR DESCRIPTION
- Update headers
- Scala 2.10 & 2.11 instead of 2.9 & 2.10
- Add sbt installation on the download page
- Remove distribution releases on the download page because 1.7.0 is not provided

Preview: http://seratch.net/scalate/ (seratch.github.io/scalate/)
