### PR TITLE
Grammar fix - subject-verb agreement

### DIFF
--- a/scalate-website/src/documentation/_scaml-reference.md
+++ b/scalate-website/src/documentation/_scaml-reference.md
@@ -201,7 +201,7 @@ xml: renders to
 <script type="text/javascript" src="javascripts/script"/>
 {pygmentize_and_compare}
 
-Complex expression are supported if you wrap them between the `{` 
+Complex expressions are supported if you wrap them between the `{` 
 and `}` characters.
 
 {pygmentize_and_compare::}
@@ -238,7 +238,7 @@ This is the same as:
 %a{:title =>title, :href => href} Stuff
 {pygmentize}
 
-Complex expression are supported if you wrap them between the `{` 
+Complex expressions are supported if you wrap them between the `{` 
 and `}` characters.
 
 {pygmentize_and_compare::}

--- a/scalate-website/src/documentation/jade-syntax.page
+++ b/scalate-website/src/documentation/jade-syntax.page
@@ -49,7 +49,7 @@ For example:
 a(title=title href=href) Stuff
 {pygmentize}
 
-Complex expression are supported if you wrap them between the `{` 
+Complex expressions are supported if you wrap them between the `{` 
 and `}` characters.
 
 {pygmentize_and_compare::}
@@ -135,7 +135,7 @@ a(title="Hello"){:href => "http://scalate.fusesource.org"} Stuff
 
 
 
-Complex expression are supported if you wrap them between the `{` 
+Complex expressions are supported if you wrap them between the `{` 
 and `}` characters.
 
 {pygmentize_and_compare::}


### PR DESCRIPTION
"Complex expression are" should be "Complex expressions are"
