### PR TITLE
Add thread-safe RW access of Introspector cache (2.11)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -3,14 +3,14 @@
 project.organization=org.fusesource
 project.name=scalate
 
-sbt.version=0.7.4
-def.scala.version=2.7.7
+sbt.version=0.13.7
+def.scala.version=2.11.5
 
 # trying out new sbt...
 #sbt.version=0.9.0-SNAPSHOT
 #def.scala.version=2.8.1.RC1
 
 project.version=1.6-SNAPSHOT
-scala.version=2.9.1
-build.scala.versions=2.9.1
+scala.version=2.11.5
+build.scala.versions=2.11.5
 project.initialize=false

--- a/project/plugins/project/build.properties
+++ b/project/plugins/project/build.properties
@@ -1,3 +1,3 @@
 #Project properties
-#Wed Dec 19 10:49:14 EST 2012
-plugin.uptodate=true
+#Mon Feb 23 19:54:15 JST 2015
+plugin.uptodate=false


### PR DESCRIPTION
`WeakHashMap` is *not* thread safe and will (has, in my experience) cause odd problems like `null`s being returned due to different threads accessing/modifying it at the same time if not synchronised.