### PR TITLE
Update a couple of documentation pages to fix grammar issue.

### DIFF
--- a/scalate-jruby/src/main/resources/haml-3.0.25/doc-src/HAML_REFERENCE.md
+++ b/scalate-jruby/src/main/resources/haml-3.0.25/doc-src/HAML_REFERENCE.md
@@ -1066,7 +1066,7 @@ For example,
 
 is the same as
 
-    %p= "This is the #{h quality} cake!"
+    %p= "This is #{h quality} cake!"
 
 and might compile to
 

--- a/scalate-website/src/documentation/_scaml-reference.md
+++ b/scalate-website/src/documentation/_scaml-reference.md
@@ -1101,7 +1101,7 @@ scaml: example
 -----------------------------
 xml: is the same as
 -----------------------------
-%p= "This is the "+(quality)+" cake!"
+%p= "This is "+(quality)+" cake!"
 {pygmentize_and_compare}
 
 and renders to

--- a/scalate-website/src/documentation/jade-syntax.page
+++ b/scalate-website/src/documentation/jade-syntax.page
@@ -970,7 +970,7 @@ p This is #{quality} cake!
 -----------------------------
 xml: is the same as
 -----------------------------
-p= "This is the "+(quality)+" cake!"
+p= "This is "+(quality)+" cake!"
 {pygmentize_and_compare}
 
 and renders to


### PR DESCRIPTION
Going through the documentation, there seems to be an extra word "the" when there shouldn't be one. I have omitted it in this pull request.