### PR TITLE
Implement expireAndCompile method for template sources

### DIFF
--- a/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
@@ -386,6 +386,32 @@ class TemplateEngine(var sourceDirectories: Traversable[File] = None, var mode: 
    */
   def cacheMisses = templateCache.synchronized { _cacheMisses }
 
+
+  /**
+    * Expire specific template source and then compile and cache again
+    */
+  def expireAndCompile(source: TemplateSource, extraBindings:Traversable[Binding]= Nil): Unit = {
+
+    templateCache.synchronized {
+
+      templateCache.get(source.uri) match {
+        case None => {
+          sourceMapLog.info(s"${source.uri} not exist in cache just compiling")
+          cache(source, compileAndLoadEntry(source, extraBindings))
+        }
+        case Some(entry) => {
+
+          sourceMapLog.info(s"${source.uri} found in cache to expire")
+          templateCache.remove(source.uri)
+
+          cache(source, compileAndLoadEntry(source, extraBindings))
+
+          sourceMapLog.info(s"${source.uri} removed from cache and compiled")
+        }
+      }
+    }
+  }
+
   /**
    * Compiles and then caches the specified template.  If the template
    * was previously cached, the previously compiled template instance


### PR DESCRIPTION
It'll help to get benefit from caching meanwhile supporting runtime compilation if it's needed