### PR TITLE
Enable compiling for Scala 2.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 scala:
   - 2.10.6
   - 2.11.8
-  - 2.12.0-RC2
+  - 2.12.0
 jdk:
   - oraclejdk8
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,17 @@ name := "Scalate"
 organization := "org.scalatra.scalate"
 version := "1.8.0-SNAPSHOT"
 scalaVersion := crossScalaVersions.value.head
-crossScalaVersions := Seq("2.12.0-RC2", "2.11.8", "2.10.6")
+crossScalaVersions := Seq("2.12.0", "2.11.8", "2.10.6")
 javaVersionPrefix in javaVersionCheck := Some("1.8")
 javacOptions ++= Seq("-source", "1.8")
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 startYear := Some(2010)
-licenses += "The Apache Software License, Version 2.0" → url("http://www.apache.org/licenses/LICENSE-2.0")
-scmInfo := Some(ScmInfo(url("http://github.com/scalate/scalate"),
-  "scm:git:git://github.com/scalate/scalate.git", Some("scm:git:ssh://git@github.com:scalate/scalate.git")))
+licenses += "The Apache Software License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
+scmInfo := Some(
+  ScmInfo(url("http://github.com/scalate/scalate"),
+  "scm:git:git://github.com/scalate/scalate.git",
+  Some("scm:git:ssh://git@github.com:scalate/scalate.git"))
+)
 homepage := Some(url("http://scalate.github.io/scalate"))
 unidocOpts(filter = scalateJrebel, scalateWar, scalateWeb)
 notPublished
@@ -23,6 +26,7 @@ lazy val scalateUtil = scalateProject("util")
     description := "Scalate Utilities.",
     parallelExecution in Test := false,
     addScalaModules(11, scalaXml, scalaParserCombinators),
+    addScalaModules(12, scalaXml, scalaParserCombinators),
     unmanagedSourceDirectories in Test += (sourceDirectory in Test).value / s"scala_${scalaBinaryVersion.value}")
 
 lazy val scalateCore = scalateProject("core")
@@ -61,12 +65,12 @@ lazy val scalateCamel = scalateProject("camel")
   .settings(
     description := "Camel component for Scalate.",
     addScalaDependentDeps(
-      10 → camelScala213,
-      10 → camelSpring213,
-      11 → camelScala214,
-      11 → camelSpring214,
-      12 → camelScala214,
-      12 → camelSpring214
+      10 -> camelScala213,
+      10 -> camelSpring213,
+      11 -> camelScala214,
+      11 -> camelSpring214,
+      12 -> camelScala214,
+      12 -> camelSpring214
     )
   )
 
@@ -201,3 +205,4 @@ lazy val scalateWikitext = scalateProject("wikitext")
   .dependsOn(scalateCore, scalateTest % Test)
   .dependsOn(wikitextConfluence, wikitextTextile, logbackClassic % Test)
   .settings(description := "Scalate WikiText integration for Markdown and Confluence notations.")
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies extends Plugin {
   val osgiCore = "org.osgi" % "org.osgi.core" % "4.2.0"
   val pegdown = "org.pegdown" % "pegdown" % "1.1.0"
   val rhinoCoffeeScript = "tv.cntt" % "rhinocoffeescript" % "1.6.2"
-  val scalamd = "org.scalatra.scalate" %% "scalamd" % "1.7.0-RC1"
+  val scalamd = "org.scalatra.scalate" %% "scalamd" % "1.7.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.0"
   val seleniumDriver = "org.seleniumhq.selenium" % "selenium-htmlunit-driver" % "2.0a5"
   val slf4jApi = "org.slf4j" % "slf4j-api" % "1.6.6"

--- a/project/ScalateBuild.scala
+++ b/project/ScalateBuild.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbt.pgp.PgpKeys
 import sbtbuildinfo.{BuildInfoPlugin, BuildInfoKeys}
 import sbtbuildinfo.BuildInfoPlugin.autoImport.BuildInfoKey
 import sbtunidoc.Plugin.UnidocKeys
-import sbtunidoc.{Plugin ⇒ SbtUnidoc}
+import sbtunidoc.{Plugin => SbtUnidoc}
 import xerial.sbt.Sonatype
 import Sonatype.SonatypeKeys
 import sbt._
@@ -34,16 +34,16 @@ object ScalateBuild extends Plugin {
   def scalateProject(id: String, base: Option[File] = None): Project =
     Project(s"scalate-$id", base.getOrElse(file(s"scalate-$id")))
 
-  def addScalaModules(scalaMajor: Int, modules: (String ⇒ ModuleID)*) = libraryDependencies := {
+  def addScalaModules(scalaMajor: Int, modules: (String => ModuleID)*) = libraryDependencies := {
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v >= scalaMajor ⇒ libraryDependencies.value ++ modules.map(_(scalaOrganization.value))
-      case _ ⇒ libraryDependencies.value
+      case Some((2, v)) if v >= scalaMajor => libraryDependencies.value ++ modules.map(_(scalaOrganization.value))
+      case _ => libraryDependencies.value
     }
   }
 
   def addScalaDependentDeps(modules: (Int, ModuleID)*) = libraryDependencies := {
     val sv = CrossVersion.partialVersion(scalaVersion.value).map(_._2).get
-    libraryDependencies.value ++ modules.collect { case m if m._1 == sv ⇒ m._2 }
+    libraryDependencies.value ++ modules.collect { case m if m._1 == sv => m._2 }
   }
 
   def notPublished = Seq(
@@ -95,7 +95,7 @@ object ScalateBuild extends Plugin {
   private def publishOpts = Sonatype.sonatypeSettings ++ Seq(
     SonatypeKeys.profileName := "org.scalatra.scalate",
     pomExtra := developersPomExtra :+ issuesPomExtra,
-    pomIncludeRepository := (_ ⇒ false),
+    pomIncludeRepository := (_ => false),
     publish := PgpKeys.publishSigned.value,
     publishLocal := PgpKeys.publishLocalSigned.value
   )
@@ -130,7 +130,7 @@ object ScalateBuild extends Plugin {
     OsgiKeys.bundleSymbolicName := s"${organization.value}.${normalizedName.value.stripPrefix("scalate-")}",
     OsgiKeys.privatePackage := Seq("org.fusesource.scalate." + normalizedName.value.stripPrefix("scalate-")),
     OsgiKeys.importPackage := Seq("scala*;version=\"%s\"".format(osgiVersionRange(scalaVersion.value)), "*"),
-    OsgiKeys.exportPackage := OsgiKeys.privatePackage(pp ⇒ {
+    OsgiKeys.exportPackage := OsgiKeys.privatePackage(pp => {
       val p = if (!pp.head.endsWith("*")) pp.head else pp.head.substring(0, pp.head.size - 1)
       s"!$p*.impl*" +: s"$p*" +: Nil
     }).value,

--- a/scalate-util/src/test/scala_2.11/org/fusesource/scalate/util/FunSuiteSupport.scala
+++ b/scalate-util/src/test/scala_2.11/org/fusesource/scalate/util/FunSuiteSupport.scala
@@ -18,20 +18,18 @@
 package org.fusesource.scalate
 
 import java.io.File
-import collection.immutable.Map
 import util.Log
-import xml.NodeSeq
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{ ConfigMap, BeforeAndAfterAllConfigMap, FunSuite }
-import org.slf4j.LoggerFactory
 
 /**
  * @version $Revision : 1.1 $
  */
 @RunWith(classOf[JUnitRunner])
 abstract class FunSuiteSupport extends FunSuite with Log with BeforeAndAfterAllConfigMap {
+
   protected var _basedir = "."
 
   /**

--- a/scalate-util/src/test/scala_2.12/org.fusesource.scalate.util/FunSuiteSupport.scala
+++ b/scalate-util/src/test/scala_2.12/org.fusesource.scalate.util/FunSuiteSupport.scala
@@ -18,13 +18,11 @@
 package org.fusesource.scalate
 
 import java.io.File
-import collection.immutable.Map
-import util.Log
-import xml.NodeSeq
 
+import util.Log
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.{ ConfigMap, BeforeAndAfterAllConfigMap, FunSuite }
+import org.scalatest.{ BeforeAndAfterAllConfigMap, ConfigMap, FunSuite }
 import org.slf4j.LoggerFactory
 
 /**
@@ -32,6 +30,7 @@ import org.slf4j.LoggerFactory
  */
 @RunWith(classOf[JUnitRunner])
 abstract class FunSuiteSupport extends FunSuite with Log with BeforeAndAfterAllConfigMap {
+
   protected var _basedir = "."
 
   /**


### PR DESCRIPTION
All the dependencies needed for compiling in Scala 2.12.0 are available now.