### PR TITLE
reverted deleted method call

### DIFF
--- a/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ScalateTemplateProvider.scala
+++ b/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ScalateTemplateProvider.scala
@@ -103,6 +103,7 @@ class ScalateTemplateProvider extends MessageBodyWriter[AnyRef] {
         var notFound = true
         for (uri <- ServletHelper.errorUris() if notFound) {
           try {
+            engine.load(uri)
             request.setAttribute("javax.servlet.error.exception", e)
             request.setAttribute("javax.servlet.error.exception_type", e.getClass)
             request.setAttribute("javax.servlet.error.message", e.getMessage)

--- a/scalate-jersey/src/main/scala/org/fusesource/scalate/jersey/ScalateTemplateProcessor.scala
+++ b/scalate-jersey/src/main/scala/org/fusesource/scalate/jersey/ScalateTemplateProcessor.scala
@@ -154,6 +154,8 @@ class ScalateTemplateProcessor(@Context resourceConfig: ResourceConfig) extends 
         var notFound = true
         for (uri <- errorUris if notFound) {
           try {
+            engine.load(uri)
+
             // we need to expose all the errors property here...
             request.setAttribute("javax.servlet.error.exception", e)
             request.setAttribute("javax.servlet.error.exception_type", e.getClass)


### PR DESCRIPTION
It should delete only the variable that holds the return value,
but deleted the method call itself. Revive this part.

https://github.com/scalate/scalate/pull/122