### PR TITLE
avoid TraversableForwarder

### DIFF
--- a/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
@@ -34,7 +34,6 @@ import scala.compat.Platform
 import java.net.URLClassLoader
 import java.io.{ StringWriter, PrintWriter, File }
 import xml.NodeSeq
-import collection.generic.TraversableForwarder
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.ConcurrentHashMap
 
@@ -165,10 +164,7 @@ class TemplateEngine(
    * is mutated after the TemplateEngine is constructed
    */
   protected def sourceDirectoriesForwarder = {
-    val engine = this
-    new TraversableForwarder[File] {
-      protected def underlying = engine.sourceDirectories
-    }
+    this.sourceDirectories
   }
 
   /**


### PR DESCRIPTION
https://github.com/scala/scala/blob/v2.12.6/src/library/scala/collection/generic/TraversableForwarder.scala

deprecated since Scala 2.11
removed since Scala 2.13