### PR TITLE
use JavaConverters instead of JavaConversions

### DIFF
--- a/scalate-core/src/main/java/org/fusesource/scalate/japi/TemplateEngineFacade.java
+++ b/scalate-core/src/main/java/org/fusesource/scalate/japi/TemplateEngineFacade.java
@@ -22,7 +22,7 @@ import org.fusesource.scalate.RenderContext;
 import org.fusesource.scalate.TemplateEngine;
 import org.fusesource.scalate.TemplateSource;
 import org.fusesource.scalate.util.JavaInterops;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 import scala.collection.mutable.Buffer;
 
 import java.io.File;
@@ -106,16 +106,16 @@ public class TemplateEngineFacade {
     // Implementation methods
     //-------------------------------------------------------------------------
     protected Buffer<Binding> asScalaExtraBindings() {
-        return JavaConversions.asScalaBuffer(getExtraBindings());
+        return JavaConverters.asScalaBuffer(getExtraBindings());
     }
 
     protected scala.collection.immutable.Map<String, Object> asScalaImmutableMap(Map<String, Object> attributes) {
-        scala.collection.mutable.Map<String, Object> mutableAttributes = JavaConversions.mapAsScalaMap(attributes);
+        scala.collection.mutable.Map<String, Object> mutableAttributes = JavaConverters.mapAsScalaMap(attributes);
         return JavaInterops.toImmutableMap(mutableAttributes);
     }
 
     protected TemplateEngine createTemplateEngine() {
-        Buffer<File> scalaSourceDirectories = JavaConversions.asScalaBuffer(sourceDirectories);
+        Buffer<File> scalaSourceDirectories = JavaConverters.asScalaBuffer(sourceDirectories);
         return TemplateEngine.apply(scalaSourceDirectories, mode);
     }
 }


### PR DESCRIPTION
deprecated since Scala 2.12
dropped since Scala 2.13

https://github.com/scala/scala/blob/v2.12.6/src/library/scala/collection/JavaConversions.scala