### PR TITLE
Update _ssp-reference.md

### DIFF
--- a/scalate-website/src/documentation/_ssp-reference.md
+++ b/scalate-website/src/documentation/_ssp-reference.md
@@ -158,8 +158,8 @@ xml: produces
 <ul>
   <li>(1, 1)</li>
   <li>(1, 2)</li>
-  <li>(1, 1)</li>
   <li>(2, 1)</li>
+  <li>(2, 2)</li>
 </ul>
 {pygmentize_and_compare}
 


### PR DESCRIPTION
correct the result of the nested loop of 

#for (x <- 1 to 2; y <- 1 to 2)
  <li>(${x}, ${y})</li>
#end