### PR TITLE
Support for java 10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val scalateCamel = scalateProject("camel")
   .dependsOn(scalateCore, scalateTest % Test)
   .settings(
     description := "Camel component for Scalate.",
-    libraryDependencies ++= Seq(camelScala, camelSpring)
+    libraryDependencies ++= Seq(camelScala, camelSpring, jaxbApi)
   )
 
 lazy val scalateGuice = scalateProject("guice")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
   val camelScala = "org.apache.camel" % "camel-scala" % "2.21.0"
   val camelSpring = camelScala.withName("camel-spring")
   val javaxServlet = "javax.servlet" % "servlet-api" % "2.5"
+  val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.0"
   val jaxrsApi = "org.jboss.spec.javax.ws.rs" % "jboss-jaxrs-api_1.1_spec" % "1.0.1.Final"
   val jerseyCore = "com.sun.jersey" % "jersey-core" % "1.19.4"
   val jerseyServlet = "com.sun.jersey" % "jersey-servlet" % jerseyCore.revision

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   val jRebelSDK = "org.zeroturnaround" % "jr-sdk" % "4.6.2" from
     "https://repos.zeroturnaround.com/nexus/content/groups/zt-public/org/zeroturnaround/jr-sdk/4.6.2/jr-sdk-4.6.2.jar"
 
-  val jRubyComplete = "org.jruby" % "jruby-complete" % "1.6.8"
+  val jRubyComplete = "org.jruby" % "jruby-complete" % "1.7.27"
   val junit = "junit" % "junit" % "4.12"
   val karafShell = "org.apache.karaf.shell" % "org.apache.karaf.shell.console" % "4.1.5"
   val lessCssEngine = "com.asual.lesscss" % "lesscss-engine" % "1.4.2"

--- a/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/JRuby.scala
+++ b/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/JRuby.scala
@@ -17,7 +17,6 @@ class JRuby(loadPaths: List[File]) extends Log {
 
   RubyInstanceConfig.FASTEST_COMPILE_ENABLED = true
   RubyInstanceConfig.FASTSEND_COMPILE_ENABLED = true
-  RubyInstanceConfig.INLINE_DYNCALL_ENABLED = true
 
   def run(scriptlet: String*): Either[(Throwable, String), AnyRef] = this.synchronized {
     val errors: StringWriter = new StringWriter


### PR DESCRIPTION
Due to changes in Java 9, the test fails in Java 9 or later environment.
I confirmed that the test will pass in Scala 2.12.6 + Java 10 with the following changes.

- Added dependency on JAXB API for support of Java 9
- Upgraded JRuby for support of Java 9