### PR TITLE
Upgraded latest JRuby

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   val jRebelSDK = "org.zeroturnaround" % "jr-sdk" % "4.6.2" from
     "https://repos.zeroturnaround.com/nexus/content/groups/zt-public/org/zeroturnaround/jr-sdk/4.6.2/jr-sdk-4.6.2.jar"
 
-  val jRubyComplete = "org.jruby" % "jruby-complete" % "1.7.27"
+  val jRubyComplete = "org.jruby" % "jruby-complete" % "9.2.0.0"
   val junit = "junit" % "junit" % "4.12"
   val karafShell = "org.apache.karaf.shell" % "org.apache.karaf.shell.console" % "4.1.5"
   val lessCssEngine = "com.asual.lesscss" % "lesscss-engine" % "1.4.2"

--- a/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/JRuby.scala
+++ b/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/JRuby.scala
@@ -1,18 +1,16 @@
 package org.fusesource.scalate.jruby
 
 import org.fusesource.scalate.util.Log
-import java.io.{ StringWriter, File }
+import java.io.StringWriter
 import org.jruby.RubyInstanceConfig
 import org.jruby.embed.{ LocalContextScope, ScriptingContainer }
-import collection.JavaConverters._
 
 /**
  * A simple interface to the jruby interpreter
  */
-class JRuby(loadPaths: List[File]) extends Log {
+class JRuby extends Log {
 
   var container = new ScriptingContainer(LocalContextScope.SINGLETON)
-  container.getProvider.setLoadPaths(loadPaths.asJava)
   container.setCompileMode(RubyInstanceConfig.CompileMode.JIT)
 
   RubyInstanceConfig.FASTEST_COMPILE_ENABLED = true

--- a/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/Sass.scala
+++ b/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/Sass.scala
@@ -2,7 +2,6 @@ package org.fusesource.scalate.jruby
 
 import org.fusesource.scalate.util.Log
 import org.fusesource.scalate.{ TemplateException, RenderContext, TemplateEngine, TemplateEngineAddOn }
-import java.io.File
 import org.fusesource.scalate.filter.{ NoLayoutFilter, CssFilter, Pipeline, Filter }
 
 /**
@@ -14,7 +13,7 @@ import org.fusesource.scalate.filter.{ NoLayoutFilter, CssFilter, Pipeline, Filt
 object Sass extends TemplateEngineAddOn with Log {
 
   def apply(te: TemplateEngine) = {
-    val jruby = new JRuby(List[File]())
+    val jruby = new JRuby
     if (!te.filters.contains("sass")) {
       val sass = new Sass(jruby, te)
       te.filters += "sass" -> Pipeline(List(sass, CssFilter))


### PR DESCRIPTION
 - upgrade latest JRuby 9.2.0.0
 - Deleted calling `setLoadPath`
   In the latest JRuby, `setLoadPath` has been deleted as the load
   path of the script has been integrated with the Java classpath.
   Therefore, deleted the call to `setLoadPath`.