### PR TITLE
Improve sanitization performance

### DIFF
--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/RenderHelper.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/RenderHelper.scala
@@ -68,16 +68,16 @@ object RenderHelper {
     text.foldLeft(new StringBuffer)((acc, ch) => sanitize(ch, acc)).toString
 
   private def sanitize(ch: Char, buffer: StringBuffer): StringBuffer = {
-    buffer.append(ch match {
-      case '"' => { "&quot;" }
-      case '&' => { "&amp;" }
-      case '<' => { "&lt;" }
-      case '>' => { "&gt;" }
+    ch match {
+      case '"' => buffer.append("&quot;")
+      case '&' => buffer.append("&amp;")
+      case '<' => buffer.append("&lt;")
+      case '>' => buffer.append("&gt;")
       // Not sure if there are other chars the need sanitization.. but if we do find
       // some, then the following might work:
-      //    case xxx   => { "&#x" + ch.toInt.toHexString + ";" }
-      case _ => ch
-    })
+      //    case xxx   => buffer.append( "&#x" + ch.toInt.toHexString + ";" )
+      case _ => buffer.append(ch)
+    }
   }
 
   def attributes(context: RenderContext, entries: List[(Any, Any)]): Unit = {


### PR DESCRIPTION
In a benchmark I'm running `RenderHelper.sanitize` is responsible for about 50% of CPU time consumed by `TemplateEngine.layout`. 

During the sanitization, a regular character (one which doesn't need to be replaced) goes through a sequence of needles transformations, namely: 
- being boxed as a `java.lang.Character`,
- getting converted to a String with `java.lang.Character.toString()`
- being appended to the `StringBuffer` as a single character String

This pull request changes this path to just calling `StringBuffer.append(char)`.

![templateengine layout](https://user-images.githubusercontent.com/9465998/47253757-19364e00-d458-11e8-80e3-ebb535d3a9fc.png)
