### PR TITLE
Fix parser-combinators bin-compatibility issue in Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,12 +36,13 @@ lazy val scalateUtil = scalateProject("util")
     libraryDependencies ++= Seq(
       junit % Test,
       logbackClassic % Test,
-      slf4jApi
+      slf4jApi,
+      s"${scalaOrganization.value}.modules" %% "scala-parser-combinators" %
+        (if (scalaVersion.value.startsWith("2.11")) "1.1.1" else "1.1.2"),
+      s"${scalaOrganization.value}.modules" %% "scala-xml" % "1.2.0",
     ),
     libraryDependencies ++= scalaTest.value.map(_ % Test),
     parallelExecution in Test := false,
-    addScalaModules(11, scalaXml, scalaParserCombinators),
-    addScalaModules(12, scalaXml, scalaParserCombinators),
     unmanagedSourceDirectories in Test += (sourceDirectory in Test).value / s"scala_${scalaBinaryVersion.value}")
 
 lazy val scalateCore = scalateProject("core")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,8 +40,6 @@ object Dependencies {
   val seleniumDriver = "org.seleniumhq.selenium" % "selenium-htmlunit-driver" % "2.52.0"
   val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.26"
   val springMVC = "org.springframework" % "spring-webmvc" % "5.1.6.RELEASE"
-  val scalaParserCombinators = (org: String) => s"$org.modules" %% "scala-parser-combinators" % "1.1.2"
-  val scalaXml = (org: String) => s"$org.modules" %% "scala-xml" % "1.2.0"
   val scalaCompiler: (String, String) => ModuleID = _ % "scala-compiler" % _
   val scalaReflect: (String, String) => ModuleID = _ % "scala-reflect" % _
   val snakeYaml = "org.yaml" % "snakeyaml" % "1.24"

--- a/project/ScalateBuild.scala
+++ b/project/ScalateBuild.scala
@@ -35,18 +35,6 @@ object ScalateBuild {
   def scalateProject(id: String, base: Option[File] = None) =
     Project(s"scalate-$id", base.getOrElse(file(s"scalate-$id")))
 
-  def addScalaModules(scalaMajor: Int, modules: (String => ModuleID)*) = libraryDependencies := {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v >= scalaMajor => libraryDependencies.value ++ modules.map(_(scalaOrganization.value))
-      case _ => libraryDependencies.value
-    }
-  }
-
-  def addScalaDependentDeps(modules: (Int, ModuleID)*) = libraryDependencies := {
-    val sv = CrossVersion.partialVersion(scalaVersion.value).map(_._2).get
-    libraryDependencies.value ++ modules.collect { case m if m._1 == sv => m._2 }
-  }
-
   def notPublished = Seq(
     publishArtifact := false,
     publish := {},

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scaml/ScamlTemplateErrorTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scaml/ScamlTemplateErrorTest.scala
@@ -107,17 +107,31 @@ class ScamlTemplateErrorTest extends ScamlTestSupport {
   //      "')' expected but ',' found at 2.22")
   //  }
 
-  // since parser-combinators 1.1.2
+  // since scala-parser-combinators 1.1.2
   // https://github.com/scala/scala-parser-combinators/commit/a6b2b3999dab
-  if (!scala.util.Properties.versionNumberString.startsWith("2.10")) {
-    testInvalidSyntaxException(
-      "Unexpected comma in html attribute list",
-      """
+  val scalaV = scala.util.Properties.versionNumberString
+  if (!scalaV.startsWith("2.10")) {
+
+    if (scalaV.startsWith("2.11")) {
+      // scala-parser-combinators 1.1.1
+      testInvalidSyntaxException(
+        "Unexpected comma in html attribute list",
+        """
 %html
   %tab(comma="common", error="true")
   %p commas in attribute lists is a common errro
 """,
-      "string matching regex '[ \\t]+' expected but '(' found at 2.7")
+        "')' expected but ',' found at 2.22")
+    } else {
+      testInvalidSyntaxException(
+        "Unexpected comma in html attribute list",
+        """
+%html
+  %tab(comma="common", error="true")
+  %p commas in attribute lists is a common errro
+""",
+        "string matching regex '[ \\t]+' expected but '(' found at 2.7")
+    }
   }
 
 }


### PR DESCRIPTION
Scala 2.11.x doesn't work with scala-parser-combinators 1.1.2 due to a bin-compatibility issue. This pull request fixes the problem. Also, we need to release a new version afterward.