### PR TITLE
replaced deprecated api

### DIFF
--- a/scalate-camel/src/test/scala/org/fusesource/scalate/camel/CamelScalateEndpointTest.scala
+++ b/scalate-camel/src/test/scala/org/fusesource/scalate/camel/CamelScalateEndpointTest.scala
@@ -79,7 +79,7 @@ class CamelScalateEndpointTest extends FunSuite {
             }
           })
 
-          val out = response.getOut
+          val out = response.getMessage
           assume(out != null, "out was null when sending to uri: " + uri + " body: " + body)
 
           val actualBody = out.getBody(classOf[String])


### PR DESCRIPTION
Replaced with getMessage as getOut has been deprecated in Apache Camel
3.0.