### PR TITLE
Deprecated Ruby sass filter

### DIFF
--- a/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/Sass.scala
+++ b/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/Sass.scala
@@ -30,6 +30,7 @@ object Sass extends TemplateEngineAddOn with Log {
   }
 }
 
+@deprecated("Since Ruby saaa is no longer maintained, Ruby sass's filter will be removed in the next major version", "1.9.6")
 class Sass(val jruby: JRuby, val engine: TemplateEngine) extends Filter {
 
   def syntax = "sass"


### PR DESCRIPTION
Ruby sass is no longer maintained, so the Ruby sass filter should be removed
in the next major version.

https://github.com/sass/ruby-sass

Also, the current Sass code in Scalate relies on a very old haml configuration
and should be removed (the current haml does not contain any code for sass).