### PR TITLE
Use slogging as cross-platform compatible logger

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ lazy val scalateUtil = scalateProject("util")
     mimaSettings,
     libraryDependencies ++= Seq(
       junit % Test,
+      slogging,
       logbackClassic % Test,
       slf4jApi,
       s"${scalaOrganization.value}.modules" %% "scala-parser-combinators" %

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,6 +19,7 @@ object Dependencies {
   val jRubyComplete = "org.jruby" % "jruby-complete" % "9.2.14.0"
   val junit = "junit" % "junit" % "4.13.1"
   val karafShell = "org.apache.karaf.shell" % "org.apache.karaf.shell.console" % "4.3.0"
+  val slogging = "biz.enef" %% "slogging-slf4j" % "0.6.2"
   // TODO: upgrade to 1.5.x
   val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val osgiCore = "org.osgi" % "org.osgi.core" % "6.0.0"

--- a/scalate-core/src/main/scala-2.13+/org/fusesource/scalate/support/ScalaCompiler.scala
+++ b/scalate-core/src/main/scala-2.13+/org/fusesource/scalate/support/ScalaCompiler.scala
@@ -18,9 +18,9 @@
 package org.fusesource.scalate.support
 
 import java.io.{ File, PrintWriter, StringWriter }
-
 import org.fusesource.scalate._
-import org.fusesource.scalate.util.{ ClassPathBuilder, Log }
+import org.fusesource.scalate.util.ClassPathBuilder
+import slogging.StrictLogging
 
 import scala.reflect.internal.util.{ FakePos, NoPosition, Position }
 import scala.runtime.ByteRef
@@ -28,7 +28,7 @@ import scala.tools.nsc.{ Global, Settings }
 import scala.tools.nsc.reporters.{ ConsoleReporter, Reporter }
 import scala.util.parsing.input.OffsetPosition
 
-object ScalaCompiler extends Log {
+object ScalaCompiler {
 
   def create(engine: TemplateEngine): ScalaCompiler = {
     Thread.currentThread.getContextClassLoader match {
@@ -40,12 +40,10 @@ object ScalaCompiler extends Log {
 
 }
 
-import org.fusesource.scalate.support.ScalaCompiler._
-
 class ScalaCompiler(
   bytecodeDirectory: File,
   classpath: String,
-  combineClasspath: Boolean = false) extends Compiler {
+  combineClasspath: Boolean = false) extends Compiler with StrictLogging {
 
   val settings = generateSettings(bytecodeDirectory, classpath, combineClasspath)
 
@@ -134,10 +132,10 @@ class ScalaCompiler(
       classPathFromClassLoader
     }
 
-    debug("using classpath: " + useCP)
-    debug("system class loader: " + ClassLoader.getSystemClassLoader)
-    debug("context class loader: " + Thread.currentThread.getContextClassLoader)
-    debug("scalate class loader: " + getClass.getClassLoader)
+    logger.debug("using classpath: " + useCP)
+    logger.debug("system class loader: " + ClassLoader.getSystemClassLoader)
+    logger.debug("context class loader: " + Thread.currentThread.getContextClassLoader)
+    logger.debug("scalate class loader: " + getClass.getClassLoader)
 
     val settings = new Settings(errorHandler)
     settings.classpath.value = useCP
@@ -154,7 +152,7 @@ class ScalaCompiler(
   }
 
   protected def createCompiler(settings: Settings, reporter: Reporter): Global = {
-    debug("creating non-OSGi compiler")
+    logger.debug("creating non-OSGi compiler")
     new Global(settings, reporter)
   }
 }

--- a/scalate-core/src/main/scala-2.13-/org/fusesource/scalate/support/ScalaCompiler.scala
+++ b/scalate-core/src/main/scala-2.13-/org/fusesource/scalate/support/ScalaCompiler.scala
@@ -122,10 +122,10 @@ class ScalaCompiler(
       classPathFromClassLoader
     }
 
-    debug("using classpath: " + useCP)
-    debug("system class loader: " + ClassLoader.getSystemClassLoader)
-    debug("context class loader: " + Thread.currentThread.getContextClassLoader)
-    debug("scalate class loader: " + getClass.getClassLoader)
+    logger.debug("using classpath: " + useCP)
+    logger.debug("system class loader: " + ClassLoader.getSystemClassLoader)
+    logger.debug("context class loader: " + Thread.currentThread.getContextClassLoader)
+    logger.debug("scalate class loader: " + getClass.getClassLoader)
 
     val settings = new Settings(errorHandler)
     settings.classpath.value = useCP
@@ -142,7 +142,7 @@ class ScalaCompiler(
   }
 
   protected def createCompiler(settings: Settings, reporter: Reporter): Global = {
-    debug("creating non-OSGi compiler")
+    logger.debug("creating non-OSGi compiler")
     new Global(settings, reporter)
   }
 }

--- a/scalate-core/src/main/scala/org/fusesource/scalate/DefaultRenderContext.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/DefaultRenderContext.scala
@@ -18,22 +18,19 @@
 package org.fusesource.scalate
 
 import java.io._
-
 import org.fusesource.scalate.support.AttributesHashMap
-import org.fusesource.scalate.util.{ Log, Resource }
+import org.fusesource.scalate.util.Resource
+import slogging.StrictLogging
 
 import scala.collection.mutable.Stack
 
-object DefaultRenderContext extends Log
 /**
  * Default implementation of [[org.fusesource.scalate.RenderContext]]
  */
 class DefaultRenderContext(
   private[this] val _requestUri: String,
   val engine: TemplateEngine,
-  var out: PrintWriter = new PrintWriter(new StringWriter())) extends RenderContext {
-
-  import DefaultRenderContext._
+  var out: PrintWriter = new PrintWriter(new StringWriter())) extends RenderContext with StrictLogging {
 
   val attributes: AttributeMap = new AttributesHashMap() {
     update("context", DefaultRenderContext.this)
@@ -89,7 +86,7 @@ class DefaultRenderContext(
     outStack.push(out)
     out = new PrintWriter(buffer)
     try {
-      debug("rendering template %s", template)
+      logger.debug("rendering template %s", template)
       template.render(this)
       out.close()
       buffer.toString

--- a/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
@@ -21,7 +21,6 @@ import java.io.{ File, PrintWriter, StringWriter }
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
-
 import org.fusesource.scalate.filter._
 import org.fusesource.scalate.jade.JadeCodeGenerator
 import org.fusesource.scalate.layout.{ LayoutStrategy, NullLayoutStrategy }
@@ -30,6 +29,7 @@ import org.fusesource.scalate.scaml.ScamlCodeGenerator
 import org.fusesource.scalate.ssp.SspCodeGenerator
 import org.fusesource.scalate.support._
 import org.fusesource.scalate.util._
+import slogging.{ Logger, LoggerFactory, StrictLogging }
 
 import scala.collection.immutable.TreeMap
 import scala.collection.mutable.HashMap
@@ -39,8 +39,6 @@ import scala.util.parsing.input.{ OffsetPosition, Position }
 import scala.xml.NodeSeq
 
 object TemplateEngine {
-
-  val log = Log(getClass)
 
   def apply(sourceDirectories: Iterable[File], mode: String): TemplateEngine = {
     new TemplateEngine(sourceDirectories, mode)
@@ -66,8 +64,7 @@ object TemplateEngine {
  */
 class TemplateEngine(
   var sourceDirectories: Iterable[File] = None,
-  var mode: String = System.getProperty("scalate.mode", "production")) {
-  import TemplateEngine.log._
+  var mode: String = System.getProperty("scalate.mode", "production")) extends StrictLogging {
 
   private case class CacheEntry(
     template: Template,
@@ -142,7 +139,7 @@ class TemplateEngine(
         } catch {
           case e: Throwable =>
             // if it's not, then disable class reloading..
-            debug("Scala compiler not found on the class path. Template reloading disabled.")
+            logger.debug("Scala compiler not found on the class path. Template reloading disabled.")
             allowReload = false
             compilerInstalled = false
         }
@@ -153,7 +150,7 @@ class TemplateEngine(
           Boots.invokeBoot(clazz, bootInjections)
 
         case _ =>
-          info("No bootstrap class " + bootClassName + " found on classloader: " + classLoader)
+          logger.info("No bootstrap class " + bootClassName + " found on classloader: " + classLoader)
       }
     }
   }
@@ -257,7 +254,7 @@ class TemplateEngine(
 
   // Discover bits that can enhance the default template engine configuration. (like filters)
   ClassFinder.discoverCommands[TemplateEngineAddOn]("META-INF/services/org.fusesource.scalate/addon.index").foreach { addOn =>
-    debug("Installing Scalate add on " + addOn.getClass)
+    logger.debug("Installing Scalate add on " + addOn.getClass)
     addOn(this)
   }
 
@@ -286,7 +283,7 @@ class TemplateEngine(
           _workingDirectory = f
           f.deleteOnExit
         } else {
-          warn("Could not delete file %s so we could create a temp directory", f)
+          logger.warn("Could not delete file %s so we could create a temp directory", f)
           _workingDirectory = new File(new File(System.getProperty("java.io.tmpdir")), "_scalate")
         }
       }
@@ -731,7 +728,7 @@ class TemplateEngine(
       templateCache += (source.uri -> ce)
     }
     val answer = ce.template
-    debug("Loaded uri: " + source.uri + " template: " + answer)
+    logger.debug("Loaded uri: " + source.uri + " template: " + answer)
     answer
   }
 
@@ -750,7 +747,7 @@ class TemplateEngine(
     new File(sourceDirectory, uri.replace(':', '_') + ".scala")
   }
 
-  protected val sourceMapLog = Log(getClass, "SourceMap")
+  protected val sourceMapLog = LoggerFactory.getLogger(s"$loggerName.SourceMap")
 
   private def compileAndLoad(
     source: TemplateSource,
@@ -850,7 +847,7 @@ class TemplateEngine(
               CompilerError(uri, olderror.message, pos, olderror)
             }
         }
-        error(e)
+        logger.error("Caught exception", e)
         if (e.errors.isEmpty) {
           throw e
         } else {

--- a/scalate-core/src/main/scala/org/fusesource/scalate/TemplateSource.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/TemplateSource.scala
@@ -20,10 +20,10 @@ package org.fusesource.scalate
 import java.io.File
 import java.net.{ URI, URL }
 import java.util.regex.Pattern
-
 import org.fusesource.scalate.support._
 import org.fusesource.scalate.util.Strings.isEmpty
 import org.fusesource.scalate.util._
+import slogging.StrictLogging
 
 import scala.io.Source
 
@@ -32,8 +32,7 @@ import scala.io.Source
  *
  * @version $Revision : 1.1 $
  */
-trait TemplateSource extends Resource {
-  import TemplateSource.log._
+trait TemplateSource extends Resource with StrictLogging {
 
   var engine: TemplateEngine = _
   private[this] var _packageName: String = ""
@@ -125,7 +124,7 @@ trait TemplateSource extends Resource {
         if (sep != "/") {
           // on windows lets replace the \ in a directory name with /
           val newName = name.replace('\\', '/')
-          debug("converted windows path into: " + newName)
+          logger.debug("converted windows path into: " + newName)
           newName
         } else {
           name
@@ -165,7 +164,6 @@ trait TemplateSource extends Resource {
  * Helper methods to create a [[org.fusesource.scalate.TemplateSource]] from various sources
  */
 object TemplateSource {
-  val log = Log(getClass)
 
   /**
    * Creates a [[org.fusesource.scalate.TemplateSource]] from the actual String contents using the given

--- a/scalate-core/src/main/scala/org/fusesource/scalate/console/ConsoleHelper.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/console/ConsoleHelper.scala
@@ -23,7 +23,7 @@ import java.io.File
 import _root_.javax.servlet.ServletContext
 import _root_.org.fusesource.scalate.RenderContext
 import _root_.org.fusesource.scalate.servlet.ServletRenderContext
-import org.fusesource.scalate.util.{ Log, SourceMap, SourceMapInstaller }
+import org.fusesource.scalate.util.{ SourceMap, SourceMapInstaller }
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.SortedMap
@@ -57,8 +57,6 @@ case class SourceLine(
     }
   }
 }
-
-object ConsoleHelper extends Log
 
 /**
  * Helper snippets for creating the console

--- a/scalate-core/src/main/scala/org/fusesource/scalate/filter/CoffeeScriptFilter.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/filter/CoffeeScriptFilter.scala
@@ -19,10 +19,9 @@ package org.fusesource.scalate
 package filter
 
 import java.util.concurrent.atomic.AtomicBoolean
-
 import javax.script.ScriptException
 import org.fusesource.scalate.support.RenderHelper
-import org.fusesource.scalate.util.Log
+import slogging.StrictLogging
 import tv.cntt.rhinocoffeescript.Compiler
 
 /**
@@ -32,7 +31,7 @@ import tv.cntt.rhinocoffeescript.Compiler
  *
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
-object CoffeeScriptFilter extends Filter with Log {
+object CoffeeScriptFilter extends Filter with StrictLogging {
 
   /**
    * Server side compilation of coffeescript is enabled by default. Disable this flag
@@ -56,7 +55,7 @@ object CoffeeScriptFilter extends Filter with Log {
       // we don't have rhino on the classpath
       // so lets do client side compilation
       if (warnedMissingRhino.compareAndSet(false, true)) {
-        warn("No Rhino on the classpath: " + e + ". Using client side CoffeeScript compile", e)
+        logger.warn("No Rhino on the classpath: " + e + ". Using client side CoffeeScript compile", e)
       }
       clientSideCompile
     }
@@ -65,7 +64,7 @@ object CoffeeScriptFilter extends Filter with Log {
       try {
         CoffeeScriptCompiler.compile(content, Some(context.currentTemplate)).fold({
           error =>
-            warn("Could not compile coffeescript: " + error, error)
+            logger.warn("Could not compile coffeescript: " + error, error)
             throw new CompilerException(error.message, Nil)
         }, {
           coffee =>
@@ -88,7 +87,7 @@ object CoffeeScriptFilter extends Filter with Log {
 /**
  * Compiles a .coffee file into JS on the server side
  */
-object CoffeeScriptPipeline extends Filter with Log {
+object CoffeeScriptPipeline extends Filter with StrictLogging {
 
   /**
    * Installs the coffeescript pipeline
@@ -101,7 +100,7 @@ object CoffeeScriptPipeline extends Filter with Log {
   def filter(context: RenderContext, content: String) = {
     CoffeeScriptCompiler.compile(content, Some(context.currentTemplate)).fold({
       error =>
-        warn("Could not compile coffeescript: " + error, error)
+        logger.warn("Could not compile coffeescript: " + error, error)
         throw new CompilerException(error.message, Nil)
     }, {
       coffee => coffee

--- a/scalate-core/src/main/scala/org/fusesource/scalate/layout/DefaultLayoutStrategy.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/layout/DefaultLayoutStrategy.scala
@@ -19,9 +19,8 @@ package org.fusesource.scalate
 package layout
 
 import org.fusesource.scalate.util.Strings.isEmpty
-import org.fusesource.scalate.util.{ Log, ResourceNotFoundException }
-
-object DefaultLayoutStrategy extends Log
+import org.fusesource.scalate.util.ResourceNotFoundException
+import slogging.StrictLogging
 
 /**
  * The default implementation of <code>LayoutStrategy</code>.
@@ -34,8 +33,7 @@ object DefaultLayoutStrategy extends Log
  *
  * @version $Revision : 1.1 $
  */
-class DefaultLayoutStrategy(val engine: TemplateEngine, val defaultLayouts: String*) extends LayoutStrategy {
-  import DefaultLayoutStrategy._
+class DefaultLayoutStrategy(val engine: TemplateEngine, val defaultLayouts: String*) extends LayoutStrategy with StrictLogging {
 
   def layout(template: Template, context: RenderContext): Unit = {
 
@@ -50,14 +48,14 @@ class DefaultLayoutStrategy(val engine: TemplateEngine, val defaultLayouts: Stri
         if (isLayoutDisabled(layout))
           noLayout(body, context)
         else if (!tryLayout(layout, body, context)) {
-          debug("Could not load layout resource: %s", layout)
+          logger.debug("Could not load layout resource: %s", layout)
           noLayout(body, context)
         }
 
       case _ =>
         val layoutName = defaultLayouts.find(tryLayout(_, body, context))
         if (layoutName.isEmpty) {
-          debug("Could not load any of the default layout resource: %s", defaultLayouts)
+          logger.debug("Could not load any of the default layout resource: %s", defaultLayouts)
           noLayout(body, context)
         }
     }
@@ -69,13 +67,13 @@ class DefaultLayoutStrategy(val engine: TemplateEngine, val defaultLayouts: Stri
     }
 
     try {
-      debug("Attempting to load layout: %s", layoutTemplate)
+      logger.debug("Attempting to load layout: %s", layoutTemplate)
 
       context.attributes("scalateLayouts") = layoutTemplate :: context.attributeOrElse[List[String]]("scalateLayouts", List())
       context.attributes("body") = body
       engine.load(layoutTemplate).render(context)
 
-      debug("layout completed of: %s", layoutTemplate)
+      logger.debug("layout completed of: %s", layoutTemplate)
       true
     } catch {
       case e: ResourceNotFoundException =>
@@ -83,7 +81,7 @@ class DefaultLayoutStrategy(val engine: TemplateEngine, val defaultLayouts: Stri
         false
       case e: Exception =>
         removeLayout
-        error(e, "Unhandled: %s", e)
+        logger.error(s"Unhandled: $e", e)
         throw e
     }
   }

--- a/scalate-core/src/main/scala/org/fusesource/scalate/mustache/MustacheCodeGenerator.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/mustache/MustacheCodeGenerator.scala
@@ -18,19 +18,16 @@
 package org.fusesource.scalate.mustache
 
 import org.fusesource.scalate._
-import support.{ Code, AbstractCodeGenerator }
+import slogging.StrictLogging
+import support.{ AbstractCodeGenerator, Code }
+
 import collection.mutable.Stack
-import util.Log
-
 import scala.language.implicitConversions
-
-object MustacheCodeGenerator extends Log
 
 /**
  * @version $Revision: 1.1 $
  */
-class MustacheCodeGenerator extends AbstractCodeGenerator[Statement] {
-  import MustacheCodeGenerator._
+class MustacheCodeGenerator extends AbstractCodeGenerator[Statement] with StrictLogging {
 
   override val stratumName = "MSC"
 
@@ -103,7 +100,7 @@ class MustacheCodeGenerator extends AbstractCodeGenerator[Statement] {
           this << "$_scalate_$_context << \"ERROR: This implementation of mustache doesn't understand the '" + name + "' pragma\""
         case SetDelimiter(open, close) =>
         case s => {
-          warn("Unsupported statement: %s", s)
+          logger.warn("Unsupported statement: %s", s)
         }
       }
     }

--- a/scalate-core/src/main/scala/org/fusesource/scalate/mustache/MustacheParser.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/mustache/MustacheParser.scala
@@ -18,9 +18,9 @@
 package org.fusesource.scalate.mustache
 
 import util.parsing.combinator.RegexParsers
-import util.parsing.input.{ Positional, CharSequenceReader, Position }
+import util.parsing.input.{ CharSequenceReader, Position, Positional }
 import org.fusesource.scalate.InvalidSyntaxException
-import org.fusesource.scalate.util.Log
+import slogging.StrictLogging
 
 sealed abstract class Statement extends Positional
 
@@ -49,16 +49,12 @@ case class SetDelimiter(open: Text, close: Text) extends Statement
 case class ImplicitIterator(name: String) extends Statement
 case class Pragma(name: Text, options: Map[String, String]) extends Statement
 
-object MustacheParser extends Log
-
 /**
  * Parser for the Mustache template language
  *
  * @version $Revision : 1.1 $
  */
-class MustacheParser extends RegexParsers {
-
-  import MustacheParser._
+class MustacheParser extends RegexParsers with StrictLogging {
 
   private[this] var _open: String = "{{"
   private[this] var _close: String = "}}"
@@ -119,7 +115,7 @@ class MustacheParser extends RegexParsers {
     case a: SetDelimiter =>
       _open = a.open.value
       _close = a.close.value
-      debug("applying new delim '" + a)
+      logger.debug("applying new delim '" + a)
       a
   }
 

--- a/scalate-core/src/main/scala/org/fusesource/scalate/mustache/Scope.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/mustache/Scope.scala
@@ -18,14 +18,13 @@
 package org.fusesource.scalate.mustache
 
 import org.fusesource.scalate.RenderContext
+import slogging.StrictLogging
 
 import scala.collection.JavaConverters._
-
 import java.{ lang => jl, util => ju }
 import xml.NodeSeq
-import org.fusesource.scalate.util.Log
 
-object Scope extends Log {
+object Scope {
   def apply(context: RenderContext) = {
     context.attributeOrElse[Scope]("scope", RenderContextScope(context))
   }
@@ -36,8 +35,8 @@ object Scope extends Log {
  *
  * @version $Revision : 1.1 $
  */
-trait Scope {
-  import Scope._
+trait Scope extends StrictLogging {
+
   def parent: Option[Scope]
 
   def context: RenderContext
@@ -56,7 +55,7 @@ trait Scope {
           case _ => null
         }
     }
-    debug("renderVariable %s = %s on %s", name, v, this)
+    logger.debug("renderVariable %s = %s on %s", name, v, this)
     renderValue(v, unescape)
   }
 
@@ -99,7 +98,7 @@ trait Scope {
     apply(name) match {
       case Some(t) =>
         val v = toIterable(t, block)
-        debug("section value " + name + " = " + v + " in " + this)
+        logger.debug("section value " + name + " = " + v + " in " + this)
         v match {
 
           // TODO we have to be really careful to distinguish between collections of things
@@ -132,7 +131,7 @@ trait Scope {
       case None => parent match {
         case Some(ps) => ps.section(name)(block)
         case None => // do nothing, no value
-          debug("No value for " + name + " in " + this)
+          logger.debug("No value for " + name + " in " + this)
 
       }
     }
@@ -142,7 +141,7 @@ trait Scope {
     apply(name) match {
       case Some(t) =>
         val v = toIterable(t, block)
-        debug("invertedSection value " + name + " = " + v + " in " + this)
+        logger.debug("invertedSection value " + name + " = " + v + " in " + this)
         v match {
 
           // TODO we have to be really careful to distinguish between collections of things
@@ -182,14 +181,14 @@ trait Scope {
   }
 
   def childScope(name: String, v: Any)(block: Scope => Unit): Unit = {
-    debug("Creating scope for: " + v)
+    logger.debug("Creating scope for: " + v)
     val scope = createScope(name, v)
     block(scope)
   }
 
   def foreachScope[T](name: String, s: Iterable[T])(block: Scope => Unit): Unit = {
     for (i <- s) {
-      debug("Creating traversable scope for: " + i)
+      logger.debug("Creating traversable scope for: " + i)
       val scope = createScope(name, i)
       block(scope)
     }
@@ -207,7 +206,7 @@ trait Scope {
       case None => new EmptyScope(this)
       case v: AnyRef => new ObjectScope(this, v)
       case v =>
-        warn("Unable to process value: %s", v)
+        logger.warn("Unable to process value: %s", v)
         new EmptyScope(this)
     }
   }

--- a/scalate-core/src/main/scala/org/fusesource/scalate/scuery/support/Rule.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/scuery/support/Rule.scala
@@ -19,9 +19,9 @@ package org.fusesource.scalate.scuery.support
 
 import xml.{ Elem, Node, NodeSeq }
 import org.fusesource.scalate.scuery.XmlHelper._
-import org.fusesource.scalate.util.Log
+import slogging.StrictLogging
 
-object Rule extends Log {
+object Rule {
   /**
    * Combines multiple rules to a single rule
    */
@@ -44,14 +44,13 @@ object Rule extends Log {
     }
   }
 }
-import Rule._
 
 /**
  * Represents manipuluation rules
  *
  * @version $Revision : 1.1 $
  */
-trait Rule {
+trait Rule extends StrictLogging {
   def apply(node: Node): NodeSeq
 
   /**
@@ -84,7 +83,7 @@ case class ReplaceContentRule(fn: Node => NodeSeq) extends Rule {
   def apply(node: Node) = node match {
     case e: Elem =>
       val contents = fn(e)
-      debug("Replacing content = " + contents)
+      logger.debug("Replacing content = " + contents)
       replaceContent(e, contents)
     case n => n
   }
@@ -94,7 +93,7 @@ case class SetAttributeRule(name: String, fn: (Node) => String) extends Rule {
   def apply(node: Node) = node match {
     case e: Elem =>
       val value = fn(e)
-      debug("Setting attribute %s to %s", name, value)
+      logger.debug("Setting attribute %s to %s", name, value)
       setAttribute(e, name, value)
 
     case n => n
@@ -107,7 +106,7 @@ case class SetSelectiveAttributeRule(name: String, fn: (Node) => String) extends
   def apply(node: Node) = node match {
     case e: Elem =>
       val value = fn(e)
-      debug("Selectively setting attribute %s to %s", name, value)
+      logger.debug("Selectively setting attribute %s to %s", name, value)
       if (e.attribute(name).isDefined) setAttribute(e, name, value) else e
 
     case n => n

--- a/scalate-core/src/main/scala/org/fusesource/scalate/servlet/ServletResourceLoader.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/servlet/ServletResourceLoader.scala
@@ -19,15 +19,14 @@ package org.fusesource.scalate.servlet
 
 import java.io.File
 import java.net.MalformedURLException
-
 import javax.servlet.ServletContext
 import org.fusesource.scalate.util.Resource._
-import org.fusesource.scalate.util.{ FileResourceLoader, Log, ResourceLoader, ResourceNotFoundException }
+import org.fusesource.scalate.util.{ FileResourceLoader, ResourceLoader, ResourceNotFoundException }
+import slogging.StrictLogging
 
-object ServletResourceLoader extends Log {
+object ServletResourceLoader {
   def apply(context: ServletContext) = new ServletResourceLoader(context, new FileResourceLoader())
 }
-import org.fusesource.scalate.servlet.ServletResourceLoader._
 
 /**
  * Loads files using <code>ServletContext</code>.
@@ -86,12 +85,12 @@ class ServletResourceLoader(
   protected def realFile(uri: String): File = {
     def findFile(uri: String): File = {
       val path = context.getRealPath(uri)
-      debug("realPath for: " + uri + " is: " + path)
+      logger.debug("realPath for: " + uri + " is: " + path)
 
       var answer: File = null
       if (path != null) {
         val file = new File(path)
-        debug("file from realPath for: " + uri + " is: " + file)
+        logger.debug("file from realPath for: " + uri + " is: " + file)
         if (file.canRead) { answer = file }
       }
       answer

--- a/scalate-core/src/main/scala/org/fusesource/scalate/servlet/ServletTemplateEngine.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/servlet/ServletTemplateEngine.scala
@@ -18,16 +18,15 @@
 package org.fusesource.scalate.servlet
 
 import java.io.File
-
 import javax.servlet.{ ServletConfig, ServletContext }
 import org.fusesource.scalate.layout.{ DefaultLayoutStrategy, LayoutStrategy }
 import org.fusesource.scalate.util._
 import org.fusesource.scalate.{ Binding, TemplateEngine }
+import slogging.StrictLogging
 
 import scala.tools.nsc.Global
 
 object ServletTemplateEngine {
-  val log = Log(getClass)
 
   val templateEngineKey = classOf[ServletTemplateEngine].getName
 
@@ -93,8 +92,7 @@ object ServletTemplateEngine {
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 class ServletTemplateEngine(
-  val config: Config) extends TemplateEngine(ServletTemplateEngine.sourceDirectories(config)) {
-  import ServletTemplateEngine.log._
+  val config: Config) extends TemplateEngine(ServletTemplateEngine.sourceDirectories(config)) with StrictLogging {
 
   templateDirectories ::= "/WEB-INF"
   bindings = List(Binding("context", "_root_." + classOf[ServletRenderContext].getName, true, isImplicit = true))
@@ -106,7 +104,7 @@ class ServletTemplateEngine(
 
   Option(config.getInitParameter("boot.class")).foreach(clazz => bootClassName = clazz)
 
-  info("Scalate template engine using working directory: %s", workingDirectory)
+  logger.info("Scalate template engine using working directory: %s", workingDirectory)
   private def buildClassPath(): String = {
 
     val builder = new ClassPathBuilder

--- a/scalate-core/src/main/scala/org/fusesource/scalate/servlet/TemplateEngineFilter.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/servlet/TemplateEngineFilter.scala
@@ -20,9 +20,7 @@ package org.fusesource.scalate.servlet
 import javax.servlet._
 import javax.servlet.http.{ HttpServletRequest, HttpServletRequestWrapper, HttpServletResponse }
 import org.fusesource.scalate.support.TemplateFinder
-import org.fusesource.scalate.util.Log
-
-object TemplateEngineFilter extends Log
+import slogging.StrictLogging
 
 /**
  * Servlet filter which auto routes to the scalate engines for paths which have a scalate template
@@ -30,8 +28,7 @@ object TemplateEngineFilter extends Log
  *
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
-class TemplateEngineFilter extends Filter {
-  import TemplateEngineFilter._
+class TemplateEngineFilter extends Filter with StrictLogging {
 
   var config: FilterConfig = _
   var engine: ServletTemplateEngine = _
@@ -70,10 +67,10 @@ class TemplateEngineFilter extends Filter {
       case (request: HttpServletRequest, response: HttpServletResponse) =>
         val request_wrapper = wrap(request)
 
-        debug("Checking '%s'", request.getRequestURI)
+        logger.debug("Checking '%s'", request.getRequestURI)
         findTemplate(request.getRequestURI.substring(request.getContextPath.length)) match {
           case Some(template) =>
-            debug("Rendering '%s' using template '%s'", request.getRequestURI, template)
+            logger.debug("Rendering '%s' using template '%s'", request.getRequestURI, template)
             val context = new ServletRenderContext(engine, request_wrapper, response, config.getServletContext)
 
             try {
@@ -93,7 +90,7 @@ class TemplateEngineFilter extends Filter {
 
   def showErrorPage(request: HttpServletRequest, response: HttpServletResponse, e: Throwable): Unit = {
 
-    info(e, "failure: %s", e)
+    logger.info(s"failure: $e", e)
 
     // we need to expose all the errors property here...
     request.setAttribute("javax.servlet.error.exception", e)

--- a/scalate-core/src/main/scala/org/fusesource/scalate/servlet/TemplateEngineServlet.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/servlet/TemplateEngineServlet.scala
@@ -20,9 +20,8 @@ package org.fusesource.scalate.servlet
 import javax.servlet.http.{ HttpServlet, HttpServletRequest, HttpServletResponse }
 import javax.servlet.{ ServletConfig, ServletContext }
 import org.fusesource.scalate.TemplateEngine
-import org.fusesource.scalate.util.Log
 
-object TemplateEngineServlet extends Log {
+object TemplateEngineServlet {
 
   protected var singleton: TemplateEngineServlet = _
 

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/AbstractCodeGenerator.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/AbstractCodeGenerator.scala
@@ -17,14 +17,11 @@
  */
 package org.fusesource.scalate.support
 
-import org.fusesource.scalate.util.Log
 import org.fusesource.scalate.{ Binding, TemplateEngine, TemplateSource }
 
 import scala.collection.immutable.TreeMap
 import scala.language.postfixOps
 import scala.util.parsing.input.{ OffsetPosition, Position, Positional }
-
-object AbstractCodeGenerator extends Log
 
 /**
  * Provides a common base class for CodeGenerator implementations.

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/DefaultTemplatePackage.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/DefaultTemplatePackage.scala
@@ -18,9 +18,9 @@
 package org.fusesource.scalate
 package support
 
-import util.{ Log, ClassLoaders, Files }
+import slogging.StrictLogging
+import util.{ ClassLoaders, Files }
 
-object DefaultTemplatePackage extends Log
 /**
  * A TemplatePackage where we try and find an object/controller/resource type based on the name of the current template and if we can
  * find it then we create a variable called **it** of the controller type and import its values into the template.
@@ -28,8 +28,7 @@ object DefaultTemplatePackage extends Log
  * This approach can be used for JAXRS controllers or for template views of objects. It avoids having to explicitly
  * import the controller or 'it' variable from the attribute scope
  */
-class DefaultTemplatePackage extends TemplatePackage {
-  import DefaultTemplatePackage._
+class DefaultTemplatePackage extends TemplatePackage with StrictLogging {
 
   def header(source: TemplateSource, bindings: List[Binding]) = {
     bindings.find(_.name == "it") match {
@@ -56,7 +55,7 @@ class DefaultTemplatePackage extends TemplatePackage {
           case _ =>
             if (!className.split('.').last.startsWith("_")) {
               // lets ignore partial templates which are never bound to a resource directly
-              debug("Could not find a class on the classpath based on the current url: %s", cleanUri)
+              logger.debug("Could not find a class on the classpath based on the current url: %s", cleanUri)
             }
             ""
         }

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/SiteGenerator.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/SiteGenerator.scala
@@ -19,16 +19,12 @@ package org.fusesource.scalate.support
 
 import java.io.{ File, PrintWriter }
 import java.{ util => ju }
-
 import org.fusesource.scalate._
 import org.fusesource.scalate.servlet.ServletTemplateEngine
 import org.fusesource.scalate.util._
+import slogging.StrictLogging
 
 import scala.collection.JavaConverters._
-
-object SiteGenerator extends Log
-import org.fusesource.scalate.support.SiteGenerator._
-
 import scala.language.reflectiveCalls
 
 /**
@@ -37,7 +33,7 @@ import scala.language.reflectiveCalls
  *
  * @author <a href="http://macstrac.blogspot.com">James Strachan</a>
  */
-class SiteGenerator {
+class SiteGenerator extends StrictLogging {
 
   var workingDirectory: File = _
   var webappDirectory: File = _
@@ -53,8 +49,8 @@ class SiteGenerator {
       throw new IllegalArgumentException("The webappDirectory properly is not properly set")
     }
 
-    info("Generating static website from Scalate Templates and wiki files...")
-    info("template properties: " + templateProperties)
+    logger.info("Generating static website from Scalate Templates and wiki files...")
+    logger.info("template properties: " + templateProperties)
 
     val engine = new DummyTemplateEngine(webappDirectory)
     engine.classLoader = Thread.currentThread.getContextClassLoader
@@ -103,7 +99,7 @@ class SiteGenerator {
               val html = engine.layout(source, attributes)
               val sourceFile = new File(targetDirectory, appendHtmlPostfix(uri.stripPrefix("/")))
 
-              info("    processing " + file + " with uri: " + uri + " => ")
+              logger.info("    processing " + file + " with uri: " + uri + " => ")
               sourceFile.getParentFile.mkdirs
               //IOUtil.writeBinaryFile(sourceFile, transformHtml(html, uri, rootDir).getBytes("UTF-8"))
               IOUtil.writeBinaryFile(sourceFile, html.getBytes("UTF-8"))
@@ -115,7 +111,7 @@ class SiteGenerator {
             }
           } else {
             // let's copy the file across if its not a template
-            debug("    copying " + file + " with uri: " + uri + " extension: " + ext + " not in " + engine.extensions)
+            logger.debug("    copying " + file + " with uri: " + uri + " extension: " + ext + " not in " + engine.extensions)
             val sourceFile = new File(targetDirectory, uri.stripPrefix("/"))
             IOUtil.copy(file, sourceFile)
           }

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/TemplateConversions.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/TemplateConversions.scala
@@ -17,15 +17,14 @@
  */
 package org.fusesource.scalate.support
 
-import org.fusesource.scalate.util.Log
+import slogging.StrictLogging
 
 import scala.language.implicitConversions
 
 /**
  * A number of helper implicit conversions for use in templates
  */
-object TemplateConversions {
-  val log = Log(getClass); import log._
+object TemplateConversions extends StrictLogging {
 
   /**
    * Provide access to the elvis operator so that we can use it to provide null handling nicely
@@ -52,7 +51,7 @@ object TemplateConversions {
       }
     } catch {
       case e: NullPointerException =>
-        debug(e, "Handling null pointer " + e)
+        logger.debug("Handling null pointer " + e, e)
         defaultValue
     }
   }

--- a/scalate-core/src/main/scala/org/fusesource/scalate/support/TemplatePackage.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/support/TemplatePackage.scala
@@ -18,8 +18,9 @@
 package org.fusesource.scalate.support
 
 import org.fusesource.scalate.util.Strings.isEmpty
-import org.fusesource.scalate.util.{ ClassLoaders, Log }
+import org.fusesource.scalate.util.ClassLoaders
 import org.fusesource.scalate.{ Binding, TemplateSource }
+import slogging.StrictLogging
 
 /**
  * The base class for any **ScalatePackage** class added to the classpath to customize the templates
@@ -33,8 +34,7 @@ abstract class TemplatePackage {
   def header(source: TemplateSource, bindings: List[Binding]): String
 }
 
-object TemplatePackage {
-  val log = Log(getClass); import log._
+object TemplatePackage extends StrictLogging {
 
   val scalatePackageClassName = "ScalatePackage"
 
@@ -48,16 +48,16 @@ object TemplatePackage {
       else
         packageName + "." + scalatePackageClassName
 
-      debug("Trying to find Scalate Package class: " + className)
+      logger.debug("Trying to find Scalate Package class: " + className)
 
       ClassLoaders.findClass(className) match {
         case Some(clazz) =>
-          debug("using Scalate Package class: " + clazz.getName)
+          logger.debug("using Scalate Package class: " + clazz.getName)
           Some(clazz.getConstructor().newInstance().asInstanceOf[TemplatePackage])
 
         case _ =>
           if (isEmpty(packageName)) {
-            debug("No ScalatePackage class found from templates package: " + source.packageName +
+            logger.debug("No ScalatePackage class found from templates package: " + source.packageName +
               " on the class loaders: " + ClassLoaders.defaultClassLoaders)
             None
           } else {

--- a/scalate-core/src/test/scala/org/fusesource/scalate/BindingsTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/BindingsTest.scala
@@ -26,18 +26,18 @@ class BindingsTest extends TemplateTestSupport {
 
     val text = engine.layout(TemplateSource.fromText("foo.ssp", "hello ${response}"))
 
-    info("Got: " + text)
+    logger.info("Got: " + text)
   }
 
   test("Int binding with a default value") {
     engine.bindings = List(Binding("year", "Int", false, Some("1970")))
 
     val text1 = engine.layout(TemplateSource.fromText("foo2.ssp", "${year.toString}'s is the hippies era"))
-    info("Got: " + text1)
+    logger.info("Got: " + text1)
     assertResult("1970's is the hippies era") { text1.trim }
 
     val text2 = engine.layout(TemplateSource.fromText("foo3.ssp", "${year.toString}'s is the hippies era"), Map("year" -> 1950))
-    info("Got: " + text2)
+    logger.info("Got: " + text2)
     assertResult("1950's is the hippies era") { text2.trim }
   }
 }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/ExtraImportTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/ExtraImportTest.scala
@@ -20,6 +20,7 @@ package org.fusesource.scalate
 import org.fusesource.scalate.Asserts._
 
 class ExtraImportTest extends TemplateTestSupport {
+
   test("test template using custom import") {
     val template = engine.compileSsp("""
 <%@ val bean: MyBean = null %>
@@ -28,7 +29,7 @@ Hello ${if (bean != null) bean else "no bean"}
 
     val output = engine.layout("foo.ssp", template).trim
     assertContains(output, "Hello no bean")
-    debug("template generated: %s", output)
+    logger.debug("template generated: %s", output)
   }
 
   override protected def createTemplateEngine = {

--- a/scalate-core/src/test/scala/org/fusesource/scalate/FunSuiteSupport.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/FunSuiteSupport.scala
@@ -18,21 +18,20 @@
 package org.fusesource.scalate
 
 import java.io.File
-
 import org.fusesource.scalate.scuery.XmlHelper._
-import org.fusesource.scalate.util.Log
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{ BeforeAndAfterAllConfigMap, ConfigMap }
 
 import scala.xml.NodeSeq
 import org.scalatest.funsuite.AnyFunSuite
+import slogging.StrictLogging
 
 /**
  * @version $Revision : 1.1 $
  */
 @RunWith(classOf[JUnitRunner])
-abstract class FunSuiteSupport extends AnyFunSuite with Log with BeforeAndAfterAllConfigMap {
+abstract class FunSuiteSupport extends AnyFunSuite with StrictLogging with BeforeAndAfterAllConfigMap {
 
   protected var _basedir = "."
 
@@ -46,7 +45,7 @@ abstract class FunSuiteSupport extends AnyFunSuite with Log with BeforeAndAfterA
       case Some(basedir) => basedir.toString
       case _ => System.getProperty("basedir", ".")
     }
-    debug("using basedir: %s", _basedir)
+    logger.debug("using basedir: %s", _basedir)
   }
 
   def assertSize(selector: String, result: NodeSeq, expected: Int): Unit = {

--- a/scalate-core/src/test/scala/org/fusesource/scalate/InjectAttributeTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/InjectAttributeTest.scala
@@ -28,7 +28,7 @@ class InjectAttributeTest extends TemplateTestSupport {
   test("Using render context directly") {
     val helper = context.inject[SomeHelper]
     assert(helper != null)
-    log.info("got helper! " + helper)
+    logger.info("got helper! " + helper)
   }
 
   // in the following test, the compiler does not pass in the
@@ -39,7 +39,7 @@ class InjectAttributeTest extends TemplateTestSupport {
     test("Using render context directly without explicit type param") {
       val helper: SomeHelper = context.inject
       assert(helper != null)
-      log.info("got helper! " + helper)
+      logger.info("got helper! " + helper)
     }
   }
 

--- a/scalate-core/src/test/scala/org/fusesource/scalate/TemplateEngineTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/TemplateEngineTest.scala
@@ -58,7 +58,7 @@ Hello ${name}!
 
     val output = engine.layout("foo3.ssp", template, Map("name" -> "James")).trim
     assertContains(output, "Hello James")
-    debug("template generated: " + output)
+    logger.debug("template generated: " + output)
   }
 
   test("throws ResourceNotFoundException if template file does not exist") {
@@ -78,7 +78,7 @@ Hello ${name}!
     val lines = output.split('\n')
 
     for (line <- lines) {
-      debug("line: " + line)
+      logger.debug("line: " + line)
     }
 
     assertResult("<%@ val it : java.lang.String %>") { lines(0) }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/TemplateTestSupport.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/TemplateTestSupport.scala
@@ -18,13 +18,13 @@
 package org.fusesource.scalate
 
 import java.io.File
-
-import org.fusesource.scalate.util.{ IOUtil, Log }
+import org.fusesource.scalate.util.IOUtil
 import org.scalatest.ConfigMap
+import slogging.StrictLogging
 
 import scala.collection.immutable.Map
 
-abstract class TemplateTestSupport extends FunSuiteSupport with Log {
+abstract class TemplateTestSupport extends FunSuiteSupport with StrictLogging {
 
   var showOutput = false
   var engine: TemplateEngine = _
@@ -67,9 +67,9 @@ abstract class TemplateTestSupport extends FunSuiteSupport with Log {
 
   protected def logOutput(output: String): Unit = {
     if (showOutput) {
-      log.info("output: '" + output + "'")
+      logger.info("output: '" + output + "'")
     } else {
-      debug("output: '" + output + "'")
+      logger.debug("output: '" + output + "'")
     }
   }
 
@@ -128,7 +128,7 @@ abstract class TemplateTestSupport extends FunSuiteSupport with Log {
     val e = intercept[InvalidSyntaxException] {
       block
     }
-    debug("caught: " + e, e)
+    logger.debug("caught: " + e, e)
     e
   }
 

--- a/scalate-core/src/test/scala/org/fusesource/scalate/boot/BootSample.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/boot/BootSample.scala
@@ -17,20 +17,19 @@
  */
 package org.fusesource.scalate.boot
 
-import org.fusesource.scalate.util.Log
+import slogging.StrictLogging
 
 /**
  * Helper class to help test that we can write custom bootstrap code
  * using the ScalatePackage mechanism
  */
-object BootSample {
-  val log = Log(getClass); import log._
+object BootSample extends StrictLogging {
 
   var initialised = false
 
   def boot: Unit = {
     if (!initialised) {
-      info("Startup up template package bootstrap!")
+      logger.info("Startup up template package bootstrap!")
       initialised = true
     }
   }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/introspector/IntrospectorTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/introspector/IntrospectorTest.scala
@@ -123,15 +123,15 @@ class IntrospectorTest extends FunSuiteSupport {
     age.set(v, 30)
     assertResult(30) { age(v) }
 
-    debug("created bean: %s", v)
+    logger.debug("created bean: %s", v)
     // TODO....
   }
 
   def dump[T](introspector: Introspector[T]): Unit = {
-    debug("Introspector for %s", introspector.elementType.getName)
+    logger.debug("Introspector for %s", introspector.elementType.getName)
     val expressions = introspector.expressions
     for (k <- expressions.keysIterator.toSeq.sortWith(_ < _)) {
-      debug("Expression: %s = %s", k, expressions(k))
+      logger.debug("Expression: %s = %s", k, expressions(k))
     }
   }
 
@@ -139,7 +139,7 @@ class IntrospectorTest extends FunSuiteSupport {
     introspector.get(name, instance) match {
       case Some(f: Function1[_, _]) =>
         val _f = f.asInstanceOf[Function1[String, _]]
-        debug("calling function %s named %s on %s = %s", _f, name, instance, _f(arg))
+        logger.debug("calling function %s named %s on %s = %s", _f, name, instance, _f(arg))
         assertResult(expected) { _f(arg) }
       case Some(v) =>
         fail("Expected function for expression " + name + " but got " + v)
@@ -156,7 +156,7 @@ class IntrospectorTest extends FunSuiteSupport {
 
   def assertProperties(properties: collection.Seq[Property[_]], expectedSize: Int) = {
     for (property <- properties) {
-      debug("Property: %s", property)
+      logger.debug("Property: %s", property)
     }
     assertResult(expectedSize) { properties.size }
   }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/mustache/LayoutTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/mustache/LayoutTest.scala
@@ -46,8 +46,8 @@ class LayoutTest extends TemplateTestSupport {
     val output = engine.layout("sample.mustache")
 
     if (showOutput) {
-      log.info("Generated: ")
-      log.info(output)
+      logger.info("Generated: ")
+      logger.info(output)
     }
 
     assertResult(expected) {
@@ -56,7 +56,7 @@ class LayoutTest extends TemplateTestSupport {
   }
 
   override protected def createTemplateEngine = {
-    debug("Using rootDir: %s", rootDir)
+    logger.debug("Using rootDir: %s", rootDir)
     val engine = new TemplateEngine(Some(rootDir))
     engine.layoutStrategy = new DefaultLayoutStrategy(engine, "mylayout.mustache")
     engine

--- a/scalate-core/src/test/scala/org/fusesource/scalate/mustache/MustacheJSONTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/mustache/MustacheJSONTest.scala
@@ -44,7 +44,7 @@ class MustacheJSONTest extends MustacheTestSupport {
       val jsonText = if (idx >= 0) jText.substring(idx + 1) else jText
       JSON.parseFull(jsonText) match {
         case Some(json) =>
-          debug("Parsed json: %s", json)
+          logger.debug("Parsed json: %s", json)
 
           json match {
             case attributes: Map[_, _] =>

--- a/scalate-core/src/test/scala/org/fusesource/scalate/mustache/MustacheParserTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/mustache/MustacheParserTest.scala
@@ -120,15 +120,15 @@ class MustacheParserTest extends FunSuiteSupport {
   }
 
   def assertValid(text: String): List[Statement] = {
-    debug("Parsing...")
-    debug(text)
-    debug("")
+    logger.debug("Parsing...")
+    logger.debug(text)
+    logger.debug("")
 
     val lines = (new MustacheParser).parse(text)
     for (line <- lines) {
-      debug("=> " + line)
+      logger.debug("=> " + line)
     }
-    debug("")
+    logger.debug("")
     lines
   }
 
@@ -142,7 +142,7 @@ class MustacheParserTest extends FunSuiteSupport {
     val e = intercept[InvalidSyntaxException] {
       block
     }
-    debug(e, "caught: " + e)
+    logger.debug("caught: " + e, e)
     e
   }
 

--- a/scalate-core/src/test/scala/org/fusesource/scalate/mustache/MustacheTestSupport.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/mustache/MustacheTestSupport.scala
@@ -26,6 +26,7 @@ import collection.immutable.Map
  * Base class for Mustache test cases based on mustache.js and mustache.ruby test cases
  */
 abstract class MustacheTestSupport extends TemplateTestSupport {
+
   var trimOutputAndTemplate = true
 
   def mustacheTest(name: String, attributes: Map[String, Any]): Unit = mustacheTest(name, "", attributes)
@@ -37,7 +38,7 @@ abstract class MustacheTestSupport extends TemplateTestSupport {
   }
 
   protected def assertMustacheTest(name: String, attributes: Map[String, Any]): Unit = {
-    debug("Using template reasource loader: " + engine.resourceLoader)
+    logger.debug("Using template reasource loader: " + engine.resourceLoader)
 
     val template = engine.load(engine.source(name + ".html", "mustache"))
     val expectedOutput = IOUtil.loadTextFile(new File(rootDir, name + ".txt"))
@@ -49,7 +50,7 @@ abstract class MustacheTestSupport extends TemplateTestSupport {
   }
 
   override protected def createTemplateEngine = {
-    debug("Using rootDir: " + rootDir)
+    logger.debug("Using rootDir: " + rootDir)
     new TemplateEngine(Some(rootDir))
   }
 

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scaml/ScamlTestSupport.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scaml/ScamlTestSupport.scala
@@ -27,6 +27,7 @@ import org.scalatest.exceptions.TestFailedException
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 class ScamlTestSupport extends TemplateTestSupport {
+
   val testCounter = new AtomicInteger(1)
 
   val NOOP = () => {}
@@ -38,7 +39,7 @@ class ScamlTestSupport extends TemplateTestSupport {
         try {
           val output = render(description, template.trim)
           if (showOutput) {
-            log.info(output)
+            logger.info(output)
           }
           output.trim
         } finally {
@@ -57,7 +58,7 @@ class ScamlTestSupport extends TemplateTestSupport {
     test(description) {
       try {
         val data = render(description, template.trim).trim
-        debug(data)
+        logger.debug(data)
         fail("Expected InvalidSyntaxException was not thrown")
       } catch {
         case e: TestFailedException => throw e
@@ -82,7 +83,7 @@ class ScamlTestSupport extends TemplateTestSupport {
     test(description) {
       try {
         val data = render(description, template.trim).trim
-        debug(data)
+        logger.debug(data)
         fail("Expected CompilerException was not thrown")
       } catch {
         case e: TestFailedException => throw e

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scuery/LoopTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scuery/LoopTest.scala
@@ -20,6 +20,7 @@ package org.fusesource.scalate.scuery
 import _root_.org.fusesource.scalate.FunSuiteSupport
 import xml.NodeSeq
 class LoopTest extends FunSuiteSupport {
+
   val people = List(Person("James", "Beckington"), Person("Hiram", "Tampa"))
 
   val xml = <html>
@@ -120,7 +121,7 @@ class LoopTest extends FunSuiteSupport {
   }
 
   def assertTransformed(result: NodeSeq): Unit = {
-    debug("got result: %s", result)
+    logger.debug("got result: %s", result)
 
     assertResult("James") { (result \\ "td")(0).text }
     assertResult("Beckington") { (result \\ "td")(1).text }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scuery/ReplaceTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scuery/ReplaceTest.scala
@@ -20,6 +20,7 @@ package org.fusesource.scalate.scuery
 import _root_.org.fusesource.scalate.FunSuiteSupport
 
 class ReplaceTest extends FunSuiteSupport {
+
   val xml = <html>
               <body>
                 <div id="content">
@@ -40,7 +41,7 @@ class ReplaceTest extends FunSuiteSupport {
 
     val result = transformer(xml)
 
-    debug("got result: " + result)
+    logger.debug("got result: " + result)
 
     val a = (result \\ "a")(0)
     assertResult("http://scalate.fusesource.org/") { (a \ "@href").toString }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scuery/SetAttributeTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scuery/SetAttributeTest.scala
@@ -21,6 +21,7 @@ import _root_.org.fusesource.scalate.FunSuiteSupport
 import xml.Node
 
 class SetAttributeTest extends FunSuiteSupport {
+
   val xml = <html>
               <body>
                 <div id="content">
@@ -47,7 +48,7 @@ class SetAttributeTest extends FunSuiteSupport {
 
     val result = transformer(xml)
 
-    debug("got result: " + result)
+    logger.debug("got result: " + result)
 
     assertLink((result \\ "a")(0), "http://scalate.fusesource.org/", "foo", "A foo link")
     assertLink((result \\ "a")(1), "http://scalate.fusesource.org/documentation/", "bar", "A bar link")
@@ -55,7 +56,7 @@ class SetAttributeTest extends FunSuiteSupport {
   }
 
   def assertLink(a: Node, href: String, className: String, title: String): Unit = {
-    debug("testing link node: " + a)
+    logger.debug("testing link node: " + a)
     assertResult(href) { (a \ "@href").toString }
     assertResult(className) { (a \ "@class").toString }
     assertResult(title) { (a \ "@title").toString }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scuery/TransformContentsWithLoopTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scuery/TransformContentsWithLoopTest.scala
@@ -21,6 +21,7 @@ import _root_.org.fusesource.scalate.FunSuiteSupport
 import _root_.scala.xml.Node
 
 class TransformContentsWithLoopTest extends FunSuiteSupport {
+
   val people = List(Person("James", "Beckington"), Person("Hiram", "Tampa"))
 
   val xml = <ul class="people">
@@ -49,14 +50,14 @@ class TransformContentsWithLoopTest extends FunSuiteSupport {
     }
 
     val result = transformer(xml)
-    debug("got result: " + result)
+    logger.debug("got result: " + result)
 
     assertPersonLink((result \ "li" \ "a")(0), "James")
     assertPersonLink((result \ "li" \ "a")(1), "Hiram")
   }
 
   protected def assertPersonLink(a: Node, name: String): Unit = {
-    debug("Testing " + a + " for name: " + name)
+    logger.debug("Testing " + a + " for name: " + name)
     assertResult(name) { a.text }
     assertResult("http://acme.com/bookstore/" + name) { (a \ "@href").toString }
   }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scuery/TransformTableStripeTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scuery/TransformTableStripeTest.scala
@@ -21,6 +21,7 @@ import _root_.org.fusesource.scalate.FunSuiteSupport
 import xml.NodeSeq
 
 class TransformTableStripeTest extends FunSuiteSupport {
+
   val xml = <table class="people">
               <thead>
                 <tr>
@@ -65,7 +66,7 @@ class TransformTableStripeTest extends FunSuiteSupport {
   test("stripe table") {
     val transformer = new PersonTransformer(List(Person("James", "Beckington"), Person("Hiram", "Tampa")))
     val result = transformer(xml)
-    debug("got result: " + result)
+    logger.debug("got result: " + result)
 
     assertSize("tbody tr", result, 2)
     assertSize("tbody tr.odd", result, 1)
@@ -80,7 +81,7 @@ class TransformTableStripeTest extends FunSuiteSupport {
   test("stripe empty table") {
     val striper = new PersonTransformer(List())
     val result = striper(xml)
-    debug("got result: " + result)
+    logger.debug("got result: " + result)
 
     assertSize("tbody tr", result, 1)
     assertSize("tbody tr.empty", result, 1)

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scuery/TransformTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scuery/TransformTest.scala
@@ -53,7 +53,7 @@ class TransformTest extends FunSuiteSupport {
     }
 
     val result = transformer(xml)
-    debug("got result: " + result)
+    logger.debug("got result: " + result)
 
     assertResult("Hiram") { (result \\ "td")(0).text }
     assertResult("Tampa") { (result \\ "td" \\ "b")(0).text }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scuery/TransformTypedElementsTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scuery/TransformTypedElementsTest.scala
@@ -24,6 +24,7 @@ case class Car(make: String, model: String, color: String)
 case class Dog(name: String, breed: String, color: String, age: Int)
 
 class TransformTypedElementsTest extends FunSuiteSupport {
+
   val car1 = Car("Ford", "SMax", "Silver")
   val car2 = Car("Porsche", "Carerra", "Black")
   val things = List(car1, car2, Dog("Emma", "Labrador", "Golden", 9))
@@ -84,7 +85,7 @@ class TransformTypedElementsTest extends FunSuiteSupport {
     }
 
     val result = transformer(xml)
-    debug("got result: " + result)
+    logger.debug("got result: " + result)
 
     assertSize("li.car", result, 2)
     assertSize("li.car img", result, 2)

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scuery/WilleScueryTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scuery/WilleScueryTest.scala
@@ -36,9 +36,9 @@ class WilleScueryTest extends FunSuiteSupport {
 
   def show(m: => String): Unit = {
     if (verbose) {
-      info(m)
+      logger.info(m)
     } else {
-      debug(m)
+      logger.debug(m)
     }
   }
 
@@ -55,4 +55,3 @@ class WilleScueryTest extends FunSuiteSupport {
               </table>
             </div>
 }
-

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scuery/support/CssParserTestSupport.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scuery/support/CssParserTestSupport.scala
@@ -23,6 +23,7 @@ import org.fusesource.scalate.scuery.XmlHelper._
 import xml.{ Elem, Node, NodeSeq }
 
 abstract class CssParserTestSupport extends FunSuiteSupport {
+
   var parser = new CssParser
 
   def xml: Node
@@ -31,7 +32,7 @@ abstract class CssParserTestSupport extends FunSuiteSupport {
     test("assertFilter: " + selector) {
       val actual = xml.$(selector)
 
-      debug("filtering selector: %s expected: %s actual: %s", selector, expected, actual)
+      logger.debug("filtering selector: %s expected: %s actual: %s", selector, expected, actual)
       assertResult(expected) { actual }
     }
   }
@@ -44,7 +45,7 @@ abstract class CssParserTestSupport extends FunSuiteSupport {
     test(message + css + " on " + summary(node)) {
       val selector = Selector(css)
       val ancestors = ancestorsOf(node)
-      debug("testing selector: " + selector + " on " + summary(node) + " with ancestors: " + summary(ancestors))
+      logger.debug("testing selector: " + selector + " on " + summary(node) + " with ancestors: " + summary(ancestors))
       assertResult(expected) { selector.matches(node, ancestors) }
     }
   }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/scuery/support/RuleTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/scuery/support/RuleTest.scala
@@ -41,7 +41,7 @@ class RuleTest extends FunSuiteSupport {
   def assertTypes(list: List[AnyRef], types: List[Class[_]]): Unit = {
     for ((t, i) <- types.zipWithIndex) {
       val v = list(i)
-      debug("item at " + i + " = " + v + " should be " + t)
+      logger.debug("item at " + i + " = " + v + " should be " + t)
       assertResult(t, "itemn at " + i) { v.getClass }
     }
   }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/ssp/MadsForIssueTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/ssp/MadsForIssueTest.scala
@@ -82,8 +82,8 @@ object ${name} extends ${name} with LongKeyedMetaMapper[${name}]
 """)
 
     val output = engine.layout("dummy.ssp", template, attributes)
-    debug("Output:")
-    debug(output)
+    logger.debug("Output:")
+    logger.debug(output)
   }
 
 }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/ssp/ParserTestSupport.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/ssp/ParserTestSupport.scala
@@ -48,15 +48,15 @@ abstract class ParserTestSupport extends FunSuiteSupport {
   }
 
   def assertValid(text: String): List[PageFragment] = {
-    debug("Parsing...")
-    debug(text)
-    debug("")
+    logger.debug("Parsing...")
+    logger.debug(text)
+    logger.debug("")
 
     val lines = (new SspParser).getPageFragments(text)
     for (line <- lines) {
-      debug("=> " + line)
+      logger.debug("=> " + line)
     }
-    debug("")
+    logger.debug("")
     lines
   }
 

--- a/scalate-core/src/test/scala/org/fusesource/scalate/support/ConvertAbsoluteLinkTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/support/ConvertAbsoluteLinkTest.scala
@@ -37,7 +37,7 @@ class ConvertAbsoluteLinkTest extends FunSuiteSupport {
     test(link + " from " + requestUri) {
       val answer = Links.convertAbsoluteLinks(link, requestUri)
 
-      info("should convert " + link + " at " + requestUri + " -> " + answer)
+      logger.info("should convert " + link + " at " + requestUri + " -> " + answer)
       assertResult(expected) { answer }
     }
   }
@@ -46,7 +46,7 @@ class ConvertAbsoluteLinkTest extends FunSuiteSupport {
     test(link) {
       val answer = Links.convertAbsoluteLinks(link, "/foo/bar.html")
 
-      info("should be unchanged " + link + " -> " + answer)
+      logger.info("should be unchanged " + link + " -> " + answer)
       assertResult(link, "Should not be changed") { answer }
     }
   }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/support/TemplateConversionsTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/support/TemplateConversionsTest.scala
@@ -37,7 +37,7 @@ class TemplateConversionsTest extends FunSuiteSupport {
     for (e <- map.asScala) {
       val key = e.getKey
       val value = e.getValue
-      log.info(" " + key + " = " + value)
+      logger.info(" " + key + " = " + value)
     }
   }
 
@@ -45,7 +45,7 @@ class TemplateConversionsTest extends FunSuiteSupport {
     val a: String = null
 
     val answer = a ?: "default"
-    log.info("got answer: " + answer)
+    logger.info("got answer: " + answer)
     assertResult("default") { answer }
   }
 
@@ -53,7 +53,7 @@ class TemplateConversionsTest extends FunSuiteSupport {
     val a: String = null
 
     val answer = orElse(a, "default")
-    log.info("got answer: " + answer)
+    logger.info("got answer: " + answer)
     assertResult("default") { answer }
   }
 
@@ -61,7 +61,7 @@ class TemplateConversionsTest extends FunSuiteSupport {
     val person = Person("James", null)
 
     val answer = orElse(person.address.city, "default")
-    log.info("got answer: " + answer)
+    logger.info("got answer: " + answer)
     assertResult("default") { answer }
   }
 }

--- a/scalate-core/src/test/scala/org/fusesource/scalate/util/ObjectsTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/util/ObjectsTest.scala
@@ -31,9 +31,8 @@ class ObjectsTest extends FunSuiteSupport {
   protected def assertInstantiate[T](clazz: Class[T], injectValues: List[AnyRef] = List()): T = {
     val answer = instantiate(clazz, injectValues)
     assert(answer != null, "Should have instantiated an instance of " + clazz.getName)
-    debug("Instantiated: " + answer)
+    logger.debug("Instantiated: " + answer)
     answer
 
   }
 }
-

--- a/scalate-core/src/test/scala/scalate/Boot.scala
+++ b/scalate-core/src/test/scala/scalate/Boot.scala
@@ -17,19 +17,17 @@
  */
 package scalate
 
-import org.fusesource.scalate.util.Log
 import org.fusesource.scalate.{ MockBootstrap, TemplateEngine }
+import slogging.StrictLogging
 
 /**
  * A simple boot strap mechanism to act as a simple place to host initialisation code which can then be shared across
  * web apps or static site gen
  */
-object Boot extends Log
-class Boot(engine: TemplateEngine) {
-  import Boot._
+class Boot(engine: TemplateEngine) extends StrictLogging {
 
   def run: Unit = {
-    info("scalate bootstrap starting with template engine: %s", engine)
+    logger.info("scalate bootstrap starting with template engine: %s", engine)
     MockBootstrap.initialised = true
   }
 

--- a/scalate-guice/src/main/scala-2.12-/org/fusesource/scalate/guice/ScalateGuiceContainer.scala
+++ b/scalate-guice/src/main/scala-2.12-/org/fusesource/scalate/guice/ScalateGuiceContainer.scala
@@ -40,7 +40,7 @@ class ScalateGuiceContainer(
     wc: WebConfig): ResourceConfig = injector.getInstance(classOf[ResourceConfig])
 
   override def initiate(rc: ResourceConfig, wa: WebApplication) = {
-    debug("container created with " + rc + " properties: " + rc.getProperties)
+    logger.debug("container created with " + rc + " properties: " + rc.getProperties)
     super.initiate(rc, wa)
   }
 }

--- a/scalate-guice/src/main/scala-2.12/org/fusesource/scalate/guice/ScalateGuiceContainer.scala
+++ b/scalate-guice/src/main/scala-2.12/org/fusesource/scalate/guice/ScalateGuiceContainer.scala
@@ -40,7 +40,7 @@ class ScalateGuiceContainer(
     wc: WebConfig): ResourceConfig = injector.getInstance(classOf[ResourceConfig])
 
   override def initiate(rc: ResourceConfig, wa: WebApplication) = {
-    debug("container created with " + rc + " properties: " + rc.getProperties)
+    logger.debug("container created with " + rc + " properties: " + rc.getProperties)
     super.initiate(rc, wa)
   }
 }

--- a/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ContainerResource.scala
+++ b/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ContainerResource.scala
@@ -17,25 +17,23 @@
  */
 package org.fusesource.scalate.rest
 
+import slogging.StrictLogging
+
 import javax.ws.rs.{ POST, Path, PathParam }
-import org.fusesource.scalate.util.{ Log }
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.Response
 import javax.ws.rs.core.Response.Status
 
-object ContainerResource extends Log
-
 /**
  * @version $Revision: 1.1 $
  */
-abstract class ContainerResource[K, E, R] {
-  import ContainerResource._
+abstract class ContainerResource[K, E, R] extends StrictLogging {
 
   def container: Container[K, E]
 
   @Path("id/{id}")
   def get(@PathParam("id") key: K): R = {
-    debug("Loading id '%s'", key)
+    logger.debug("Loading id '%s'", key)
 
     container.get(key) match {
       case Some(e) => createChild(e)

--- a/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ScalateTemplateProvider.scala
+++ b/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ScalateTemplateProvider.scala
@@ -26,11 +26,9 @@ import javax.ws.rs.ext.{ Provider, MessageBodyWriter }
 import javax.ws.rs.core.{ UriInfo, MultivaluedMap, MediaType, Context }
 import org.fusesource.scalate.servlet.{ ServletRenderContext, ServletTemplateEngine, ServletHelper, TemplateEngineServlet }
 import org.fusesource.scalate.TemplateException
-import org.fusesource.scalate.util.{ Log, ResourceNotFoundException }
+import org.fusesource.scalate.util.ResourceNotFoundException
 
 import javax.ws.rs.WebApplicationException
-
-object ScalateTemplateProvider extends Log
 
 /**
  * A template provider for <a href="https://jersey.dev.java.net/">Jersey</a> using Scalate templates

--- a/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ViewWriter.scala
+++ b/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ViewWriter.scala
@@ -39,17 +39,17 @@ import java.io.OutputStream
 import java.lang.reflect.Type
 import javax.ws.rs.ext.{ MessageBodyWriter, Provider }
 import javax.servlet.ServletContext
-import javax.ws.rs.core.{ Context, MultivaluedMap, MediaType }
-import javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
-import java.lang.{ String, Class }
+import javax.ws.rs.core.{ Context, MediaType, MultivaluedMap }
+import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
+import java.lang.{ Class, String }
 import java.lang.annotation.Annotation
 import org.fusesource.scalate.support.TemplateFinder
-import org.fusesource.scalate.servlet.{ ServletTemplateEngine, ServletHelper, TemplateEngineServlet }
-import org.fusesource.scalate.util.{ Log, ResourceNotFoundException }
+import org.fusesource.scalate.servlet.{ ServletHelper, ServletTemplateEngine, TemplateEngineServlet }
+import org.fusesource.scalate.util.ResourceNotFoundException
+import slogging.StrictLogging
+
 import javax.ws.rs.core.UriInfo
 import javax.ws.rs.WebApplicationException
-
-object ViewWriter extends Log
 
 /**
  * Renders a [[org.fusesource.scalate.rest.View]] using the Scalate template engine
@@ -57,8 +57,7 @@ object ViewWriter extends Log
  * @version $Revision : 1.1 $
  */
 @Provider
-class ViewWriter[T] extends MessageBodyWriter[View[T]] {
-  import ViewWriter._
+class ViewWriter[T] extends MessageBodyWriter[View[T]] with StrictLogging {
 
   @Context
   protected var uriInfo: UriInfo = _
@@ -84,7 +83,7 @@ class ViewWriter[T] extends MessageBodyWriter[View[T]] {
       val template = view.uri
       finder.findTemplate(template) match {
         case Some(name) =>
-          info("Attempting to generate View for %s", name)
+          logger.info("Attempting to generate View for %s", name)
           // Ensure headers are committed
           //out.flush()
           view.model match {

--- a/scalate-jersey/src/main/scala/org/fusesource/scalate/console/ArchetypeResource.scala
+++ b/scalate-jersey/src/main/scala/org/fusesource/scalate/console/ArchetypeResource.scala
@@ -20,17 +20,17 @@ package org.fusesource.scalate.console
 import _root_.java.io.File
 import javax.servlet.ServletContext
 import com.sun.jersey.api.representation.Form
+
 import javax.ws.rs._
 import org.fusesource.scalate.{ NoFormParameterException, RenderContext }
 import org.fusesource.scalate.rest.View
-import org.fusesource.scalate.util.{ Log, IOUtil }
+import org.fusesource.scalate.util.IOUtil
+import slogging.StrictLogging
 
-object ArchetypeResource extends Log
 /**
  * @version $Revision : 1.1 $
  */
-class ArchetypeResource(console: Console, name: String) extends ConsoleSnippets {
-  import ArchetypeResource._
+class ArchetypeResource(console: Console, name: String) extends ConsoleSnippets with StrictLogging {
 
   var _form: Form = _
 
@@ -63,7 +63,7 @@ class ArchetypeResource(console: Console, name: String) extends ConsoleSnippets 
   @Consumes(Array("application/x-www-form-urlencoded"))
   def post(form: Form) = {
     _form = form
-    debug("Posted: %s", form)
+    logger.debug("Posted: %s", form)
 
     // TODO - find the post template
     // validate it, if missing parameters, barf and re-render the view with the current values
@@ -88,7 +88,7 @@ class ArchetypeResource(console: Console, name: String) extends ConsoleSnippets 
    * Creates a file of the given name using the body as the content
    */
   def createFile(fileName: String)(body: => Unit): Unit = {
-    info("archetype creating file: %s", fileName)
+    logger.info("archetype creating file: %s", fileName)
 
     val text = RenderContext.capture(body)
 

--- a/scalate-jersey/src/main/scala/org/fusesource/scalate/console/Console.scala
+++ b/scalate-jersey/src/main/scala/org/fusesource/scalate/console/Console.scala
@@ -17,15 +17,14 @@
  */
 package org.fusesource.scalate.console
 
-import _root_.javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
+import _root_.javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 import _root_.javax.servlet.ServletContext
 import _root_.javax.ws.rs._
 import _root_.org.fusesource.scalate.servlet.{ ServletRenderContext, ServletTemplateEngine }
 import _root_.org.fusesource.scalate.util.Constraints._
-import javax.ws.rs.core.Context
-import org.fusesource.scalate.util.Log
+import slogging.StrictLogging
 
-object Console extends Log; import Console._
+import javax.ws.rs.core.Context
 
 /**
  * The Scalate development console
@@ -33,7 +32,7 @@ object Console extends Log; import Console._
  * @version $Revision : 1.1 $
  */
 @Path("/scalate")
-class Console extends DefaultRepresentations {
+class Console extends DefaultRepresentations with StrictLogging {
 
   @Context
   var _servletContext: ServletContext = _
@@ -57,7 +56,7 @@ class Console extends DefaultRepresentations {
   @POST
   @Path("invalidateCachedTemplates")
   def invalidateCachedTemplates() = {
-    info("Clearing template cache")
+    logger.info("Clearing template cache")
     val engine = ServletTemplateEngine(servletContext)
     engine.invalidateCachedTemplates
   }

--- a/scalate-jersey/src/main/scala/org/fusesource/scalate/jersey/ScalateTemplateProcessor.scala
+++ b/scalate-jersey/src/main/scala/org/fusesource/scalate/jersey/ScalateTemplateProcessor.scala
@@ -21,27 +21,23 @@ package jersey
 import java.io.OutputStream
 import java.net.MalformedURLException
 import javax.servlet.ServletContext
-import javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
+import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 import javax.ws.rs.core.Context
-
 import com.sun.jersey.api.core.{ HttpContext, ResourceConfig }
 import com.sun.jersey.api.container.ContainerException
 import com.sun.jersey.api.view.Viewable
 import com.sun.jersey.core.reflection.ReflectionHelper
 import com.sun.jersey.server.impl.container.servlet.RequestDispatcherWrapper
 import com.sun.jersey.spi.template.ViewProcessor
-
-import org.fusesource.scalate.servlet.{ ServletTemplateEngine, ServletHelper, TemplateEngineServlet }
-import util.{ Log, ResourceNotFoundException }
-
-object ScalateTemplateProcessor extends Log
+import org.fusesource.scalate.servlet.{ ServletHelper, ServletTemplateEngine, TemplateEngineServlet }
+import slogging.StrictLogging
+import util.ResourceNotFoundException
 
 /**
  * A template processor for <a href="https://jersey.dev.java.net/">Jersey</a> using Scalate templates
  * @version $Revision : 1.1 $
  */
-class ScalateTemplateProcessor(@Context resourceConfig: ResourceConfig) extends ViewProcessor[String] {
-  import ScalateTemplateProcessor._
+class ScalateTemplateProcessor(@Context resourceConfig: ResourceConfig) extends ViewProcessor[String] with StrictLogging {
 
   @Context
   var servletContext: ServletContext = _
@@ -62,12 +58,12 @@ class ScalateTemplateProcessor(@Context resourceConfig: ResourceConfig) extends 
   def resolve(requestPath: String): String = {
 
     if (servletContext == null) {
-      warn("No servlet context")
+      logger.warn("No servlet context")
       return null
     }
     val engine = ServletTemplateEngine(servletContext)
     if (engine == null) {
-      warn("No ServletTemplateEngine context")
+      logger.warn("No ServletTemplateEngine context")
       return null
     }
 
@@ -94,7 +90,7 @@ class ScalateTemplateProcessor(@Context resourceConfig: ResourceConfig) extends 
       }
     } catch {
       case e: MalformedURLException =>
-        warn(e, "Tried to load template using Malformed URL: %s", e.getMessage)
+        logger.warn("Tried to load template using Malformed URL: ${e.getMessage}", e)
         null
     }
   }

--- a/scalate-jersey/src/main/scala/org/fusesource/scalate/jersey/ScueryTemplateProcessor.scala
+++ b/scalate-jersey/src/main/scala/org/fusesource/scalate/jersey/ScueryTemplateProcessor.scala
@@ -21,24 +21,21 @@ import java.io.OutputStream
 import java.net.MalformedURLException
 import javax.ws.rs.core.Context
 import javax.servlet.ServletContext
-import javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
+import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 import com.sun.jersey.api.view.Viewable
 import com.sun.jersey.spi.template.ViewProcessor
 import com.sun.jersey.api.core.{ HttpContext, ResourceConfig }
 import com.sun.jersey.api.container.ContainerException
 import com.sun.jersey.core.reflection.ReflectionHelper
 import org.fusesource.scalate.servlet.{ ServletHelper, TemplateEngineServlet }
-import org.fusesource.scalate.util.Log
-
-object ScueryTemplateProcessor extends Log
+import slogging.StrictLogging
 
 /**
  * A template processor for <a href="https://jersey.dev.java.net/">Jersey</a> using Scuery transformer
  * @version $Revision : 1.1 $
  */
 
-class ScueryTemplateProcessor(@Context resourceConfig: ResourceConfig) extends ViewProcessor[String] {
-  import ScueryTemplateProcessor._
+class ScueryTemplateProcessor(@Context resourceConfig: ResourceConfig) extends ViewProcessor[String] with StrictLogging {
 
   @Context
   var servletContext: ServletContext = _
@@ -61,11 +58,11 @@ class ScueryTemplateProcessor(@Context resourceConfig: ResourceConfig) extends V
 
   def resolve(requestPath: String): String = {
     if (servletContext == null) {
-      warn("No servlet context")
+      logger.warn("No servlet context")
       return null
     }
 
-    debug("Request path: " + requestPath)
+    logger.debug("Request path: " + requestPath)
     try {
       val path = if (basePath.length > 0) basePath + requestPath else requestPath
 
@@ -89,7 +86,7 @@ class ScueryTemplateProcessor(@Context resourceConfig: ResourceConfig) extends V
       }
     } catch {
       case e: MalformedURLException =>
-        warn(e, "Tried to load template using Malformed URL: %s", e.getMessage)
+        logger.warn(s"Tried to load template using Malformed URL: ${e.getMessage}", e)
         null
     }
   }
@@ -99,7 +96,7 @@ class ScueryTemplateProcessor(@Context resourceConfig: ResourceConfig) extends V
 
     paths.find {
       t =>
-        debug("Trying to find template: " + t)
+        logger.debug("Trying to find template: " + t)
         servletContext.getResource(t) ne null
     }
   }
@@ -116,7 +113,7 @@ class ScueryTemplateProcessor(@Context resourceConfig: ResourceConfig) extends V
 
     try {
 
-      debug("Attempt to find '" + resolvedPath + "'")
+      logger.debug("Attempt to find '" + resolvedPath + "'")
 
       //servletContext.getResourceAsStream(resolvedPath)
 

--- a/scalate-jersey/src/main/scala/org/fusesource/scalate/jersey/ScueryView.scala
+++ b/scalate-jersey/src/main/scala/org/fusesource/scalate/jersey/ScueryView.scala
@@ -18,18 +18,18 @@
 package org.fusesource.scalate.jersey
 
 import org.fusesource.scalate.scuery.Transformer
-import xml.{ XML, NodeSeq }
+
+import xml.{ NodeSeq, XML }
 import javax.ws.rs.core.Context
 import javax.servlet.ServletContext
 import java.net.URL
-import org.fusesource.scalate.util.{ Log, ResourceNotFoundException }
+import org.fusesource.scalate.util.ResourceNotFoundException
+import slogging.StrictLogging
 
 /**
  * @version $Revision : 1.1 $
  */
-object ScueryView extends Log
-trait ScueryView {
-  import ScueryView._
+trait ScueryView extends StrictLogging {
 
   @Context
   private[this] var _servletContext: ServletContext = _
@@ -57,15 +57,15 @@ trait ScueryView {
 
   protected def findResource(path: String): Option[URL] = {
     val cname = getClass.getName
-    debug("Using class name: " + cname)
+    logger.debug("Using class name: " + cname)
     val classDirectory = "/" + cname.replace('.', '/') + "."
 
     var answer: Option[URL] = None
     for (subDir <- List(classDirectory, ""); dir <- templateDirectories if answer.isEmpty) {
       val t = dir + subDir + path
-      debug("Trying to find template: " + t)
+      logger.debug("Trying to find template: " + t)
       val u = servletContext.getResource(t)
-      debug("Found: " + u)
+      logger.debug("Found: " + u)
       if (u != null) {
         answer = Some(u)
       }

--- a/scalate-jersey/src/main/scala/org/fusesource/scalate/rest/TransformerWriter.scala
+++ b/scalate-jersey/src/main/scala/org/fusesource/scalate/rest/TransformerWriter.scala
@@ -23,19 +23,17 @@ import java.lang.reflect.Type
 import java.net.URL
 import javax.ws.rs.ext.{ MessageBodyWriter, Provider }
 import javax.servlet.ServletContext
-import javax.ws.rs.core.{ Context, MultivaluedMap, MediaType }
-
+import javax.ws.rs.core.{ Context, MediaType, MultivaluedMap }
 import org.fusesource.scalate.scuery.Transformer
 import org.fusesource.scalate.servlet.{ ServletHelper, TemplateEngineServlet }
 import com.sun.jersey.api.core.ExtendedUriInfo
 import com.sun.jersey.api.container.ContainerException
 
 import scala.collection.JavaConverters._
-import xml.{ XML, NodeSeq }
-import javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
-import org.fusesource.scalate.util.{ Log, ResourceNotFoundException }
-
-object TransformerWriter extends Log
+import xml.{ NodeSeq, XML }
+import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
+import org.fusesource.scalate.util.ResourceNotFoundException
+import slogging.StrictLogging
 
 /**
  * Converts an Scuery [[org.fusesource.scalate.scuery.Transformer]] to output
@@ -43,8 +41,7 @@ object TransformerWriter extends Log
  * @version $Revision : 1.1 $
  */
 @Provider
-class TransformerWriter extends MessageBodyWriter[Transformer] {
-  import TransformerWriter._
+class TransformerWriter extends MessageBodyWriter[Transformer] with StrictLogging {
 
   @Context
   protected var uriInfo: ExtendedUriInfo = _
@@ -107,8 +104,8 @@ class TransformerWriter extends MessageBodyWriter[Transformer] {
       if (!resources.isEmpty) {
         val resource = resources.head
         val className = resource.getClass.getName
-        debug("resource class: " + className)
-        debug("viewName: " + viewName)
+        logger.debug("resource class: " + className)
+        logger.debug("viewName: " + viewName)
 
         try {
           val templateName = "/" + className.replace('.', '/') + "." + viewName + ".html"
@@ -177,9 +174,9 @@ class TransformerWriter extends MessageBodyWriter[Transformer] {
     var answer: Option[URL] = None
     for (dir <- templateDirectories if answer.isEmpty) {
       val t = dir + path
-      debug("Trying to find template: " + t)
+      logger.debug("Trying to find template: " + t)
       val u = servletContext.getResource(t)
-      debug("Found: " + u)
+      logger.debug("Found: " + u)
       if (u != null) {
         answer = Some(u)
       }

--- a/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/JRuby.scala
+++ b/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/JRuby.scala
@@ -1,6 +1,5 @@
 package org.fusesource.scalate.jruby
 
-import org.fusesource.scalate.util.Log
 import java.io.StringWriter
 import org.jruby.RubyInstanceConfig
 import org.jruby.embed.{ LocalContextScope, ScriptingContainer }
@@ -8,7 +7,7 @@ import org.jruby.embed.{ LocalContextScope, ScriptingContainer }
 /**
  * A simple interface to the jruby interpreter
  */
-class JRuby extends Log {
+class JRuby {
 
   var container = new ScriptingContainer(LocalContextScope.SINGLETON)
   container.setCompileMode(RubyInstanceConfig.CompileMode.JIT)

--- a/scalate-jsp-converter/src/main/scala/org/fusesource/scalate/converter/JspConverter.scala
+++ b/scalate-jsp-converter/src/main/scala/org/fusesource/scalate/converter/JspConverter.scala
@@ -18,8 +18,9 @@
 package org.fusesource.scalate.converter
 
 import org.fusesource.scalate.support.Text
+
 import util.matching.Regex.Match
-import org.fusesource.scalate.util.Log
+import slogging.StrictLogging
 
 object ExpressionLanguage {
   protected val operators = Map("eq" -> "==", "ne" -> "!=",
@@ -95,9 +96,8 @@ trait IndentWriter {
 
   def text = out.toString
 }
-object JspConverter extends Log
-class JspConverter extends IndentWriter {
-  import JspConverter._
+
+class JspConverter extends IndentWriter with StrictLogging {
 
   var coreLibraryPrefix: String = "c"
   var whenCount = 0
@@ -192,7 +192,7 @@ class JspConverter extends IndentWriter {
             print("${uri(" + asParam(exp) + ")}")
 
           case _ =>
-            warn("No converter available for tag <" + coreLibraryPrefix + ":" + name + ">: " + e)
+            logger.warn("No converter available for tag <" + coreLibraryPrefix + ":" + name + ">: " + e)
             print(e)
         }
       case _ => print(e)

--- a/scalate-jsp-converter/src/test/scala/org/fusesource/scalate/converter/ConvertJspTest.scala
+++ b/scalate-jsp-converter/src/test/scala/org/fusesource/scalate/converter/ConvertJspTest.scala
@@ -19,16 +19,15 @@ package org.fusesource.scalate.converter
 
 import _root_.org.junit.runner.RunWith
 import _root_.org.scalatestplus.junit.JUnitRunner
-
 import _root_.org.fusesource.scalate._
-import org.fusesource.scalate.util.Log
 import org.scalatest.funsuite.AnyFunSuite
+import slogging.StrictLogging
 
 /**
  * @version $Revision : 1.1 $
  */
 @RunWith(classOf[JUnitRunner])
-class ConvertJspTest extends AnyFunSuite with Log {
+class ConvertJspTest extends AnyFunSuite with StrictLogging {
 
   assertJustText("<foo/>")
   assertJustText("text <foo/> text")
@@ -182,12 +181,12 @@ whatnot""")
   }
 
   def convert(jsp: String): String = {
-    log.info("Converting JSP: " + jsp)
+    logger.info("Converting JSP: " + jsp)
 
     val converter = new JspConverter
     val result = converter.convert(jsp)
 
-    log.info(" => " + result)
+    logger.info(" => " + result)
 
     result
   }

--- a/scalate-jsp-converter/src/test/scala/org/fusesource/scalate/converter/ExpressionParseTest.scala
+++ b/scalate-jsp-converter/src/test/scala/org/fusesource/scalate/converter/ExpressionParseTest.scala
@@ -19,14 +19,14 @@ package org.fusesource.scalate.converter
 
 import _root_.org.junit.runner.RunWith
 import _root_.org.scalatestplus.junit.JUnitRunner
-import org.fusesource.scalate.util.Log
 import org.scalatest.funsuite.AnyFunSuite
+import slogging.StrictLogging
 
 /**
  * @version $Revision : 1.1 $
  */
 @RunWith(classOf[JUnitRunner])
-class ExpressionParseTest extends AnyFunSuite with Log {
+class ExpressionParseTest extends AnyFunSuite with StrictLogging {
 
   assertConvert("${foo.bar}", "foo.getBar")
   assertConvert("${foo[123]}", "foo(123)")
@@ -50,15 +50,15 @@ class ExpressionParseTest extends AnyFunSuite with Log {
   }
 
   def convert(el: String): String = {
-    log.info("Converting EL: " + el)
+    logger.info("Converting EL: " + el)
 
     val parser = new ExpressionParser
     val exp = parser.parseExpression(el)
-    log.info("Expression: " + exp)
+    logger.info("Expression: " + exp)
 
     val result = exp.asParam
 
-    log.info(" => " + result)
+    logger.info(" => " + result)
 
     result
   }

--- a/scalate-page/src/main/scala/org/fusesource/scalate/page/BlogHelper.scala
+++ b/scalate-page/src/main/scala/org/fusesource/scalate/page/BlogHelper.scala
@@ -19,12 +19,11 @@ package org.fusesource.scalate
 package page
 
 import org.fusesource.scalate.util.IOUtil._
+import slogging.StrictLogging
+
 import java.io.File
-import util.Log
 
-object BlogHelper {
-  val log = Log(getClass)
-
+object BlogHelper extends StrictLogging {
   /**
    * Returns the blog posts from the current request's directory by default sorted in date order
    */
@@ -37,7 +36,7 @@ object BlogHelper {
       .getOrElse(throw new Exception("index page not found."))
       .getParentFile
 
-    log.info("Using dir: " + dir + " at request path: " + base)
+    logger.info("Using dir: " + dir + " at request path: " + base)
 
     val index = new File(dir, "index.page")
     dir.descendants.filter(f => f != index && !f.isDirectory && f.name.endsWith(".page"))

--- a/scalate-page/src/test/scala/org/fusesource/scalate/page/FeedFilterTest.scala
+++ b/scalate-page/src/test/scala/org/fusesource/scalate/page/FeedFilterTest.scala
@@ -25,7 +25,7 @@ class FeedFilterTest extends TemplateTestSupport {
   test("feed filter") {
     val output = engine.layout("/blog/index.feed")
     if (showOutput) {
-      info("Output: " + output)
+      logger.info("Output: " + output)
     }
 
     val xml = XML.loadString(output)

--- a/scalate-test/src/main/scala/org/fusesource/scalate/test/FunSuiteSupport.scala
+++ b/scalate-test/src/main/scala/org/fusesource/scalate/test/FunSuiteSupport.scala
@@ -19,10 +19,11 @@ package org.fusesource.scalate.test
 
 import _root_.org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
-import org.scalatest.{ ConfigMap, BeforeAndAfterAllConfigMap }
+import org.scalatest.{ BeforeAndAfterAllConfigMap, ConfigMap }
+
 import java.io.File
-import org.fusesource.scalate.util.Log
 import org.scalatest.funsuite.AnyFunSuite
+import slogging.StrictLogging
 
 /**
  * @version $Revision : 1.1 $
@@ -31,7 +32,7 @@ import org.scalatest.funsuite.AnyFunSuite
 abstract class FunSuiteSupport
   extends AnyFunSuite
   with BeforeAndAfterAllConfigMap
-  with Log {
+  with StrictLogging {
 
   /**
    * Returns the base directory of the current project
@@ -43,7 +44,7 @@ abstract class FunSuiteSupport
       case Some(basedir) => Config.baseDir = basedir.toString
       case _ =>
     }
-    debug("using basedir: %s", Config.baseDir)
+    logger.debug("using basedir: %s", Config.baseDir)
   }
 
 }

--- a/scalate-test/src/main/scala/org/fusesource/scalate/test/TemplateTestSupport.scala
+++ b/scalate-test/src/main/scala/org/fusesource/scalate/test/TemplateTestSupport.scala
@@ -21,11 +21,12 @@ package test
 import java.io.File
 import util.IOUtil
 import org.scalatest.ConfigMap
+import slogging.StrictLogging
 
 /**
  * A useful base class for testing templates
  */
-class TemplateTestSupport extends FunSuiteSupport {
+class TemplateTestSupport extends FunSuiteSupport with StrictLogging {
 
   var engine: TemplateEngine = _
   var showOutput = false
@@ -50,7 +51,7 @@ class TemplateTestSupport extends FunSuiteSupport {
 
   def assertOutput(expectedOutput: String, template: TemplateSource, attributes: Map[String, Any] = Map(), trim: Boolean = false): String = {
     var output = engine.layout(template, attributes)
-    debug("output: '" + output + "'")
+    logger.debug("output: '" + output + "'")
 
     if (trim) {
       output = output.trim
@@ -65,9 +66,9 @@ class TemplateTestSupport extends FunSuiteSupport {
   def assertOutputContains(source: TemplateSource, attributes: Map[String, Any], expected: String*): String = {
     val output = engine.layout(source, attributes)
     if (showOutput) {
-      info("output: '" + output + "'")
+      logger.info("output: '" + output + "'")
     } else {
-      debug("output: '" + output + "'")
+      logger.debug("output: '" + output + "'")
     }
 
     assertTextContains(output, "template " + source, expected: _*)

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassFinder.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassFinder.scala
@@ -17,6 +17,8 @@
  */
 package org.fusesource.scalate.util
 
+import slogging.LazyLogging
+
 import java.io.InputStream
 import java.util.Properties
 
@@ -26,9 +28,7 @@ import java.util.Properties
  *
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
-object ClassFinder {
-
-  val log = Log(getClass); import log._
+object ClassFinder extends LazyLogging {
 
   def discoverCommands[T](
     indexPath: String,
@@ -55,7 +55,7 @@ object ClassFinder {
               }
             } catch {
               case e: Throwable =>
-                debug(e, "Invalid class: %s", name)
+                logger.debug(s"Invalid class: $name", e)
                 None
             }
         }
@@ -70,10 +70,10 @@ object ClassFinder {
     val resources = cl.getResources(indexPath)
     while (resources.hasMoreElements) {
       val url = resources.nextElement
-      debug("loaded commands from %s", url)
+      logger.debug("loaded commands from %s", url)
       val p = loadProperties(url.openStream)
       if (p == null) {
-        warn("Could not load class list from: %s", url)
+        logger.warn("Could not load class list from: %s", url)
       }
       val enum = p.keys
       while (enum.hasMoreElements) {
@@ -81,7 +81,7 @@ object ClassFinder {
       }
     }
     rc = rc.distinct
-    debug("loaded classes: %s", rc)
+    logger.debug("loaded classes: %s", rc)
     rc
   }
 

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassLoaders.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassLoaders.scala
@@ -17,19 +17,19 @@
  */
 package org.fusesource.scalate.util
 
+import slogging.LazyLogging
+
 import java.net.URL
 import scala.language.existentials
 
 object ClassLoaders {
-
-  val log = Log(getClass)
 
   /**
    * Returns the default class loaders to use for loading which is the current threads context class loader
    * and the class loader which loaded scalate-core by default
    */
   def defaultClassLoaders: List[ClassLoader] = {
-    List(Thread.currentThread.getContextClassLoader, classOf[Logging].getClassLoader)
+    List(Thread.currentThread.getContextClassLoader, classOf[LazyLogging].getClassLoader)
   }
 
   /**

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassPathBuilder.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassPathBuilder.scala
@@ -17,14 +17,16 @@
  */
 package org.fusesource.scalate.util
 
+import slogging.LazyLogging
+
 import java.io.File
 import java.net.{ URI, URLClassLoader }
 import scala.collection.mutable.ArrayBuffer
 import java.util.jar.{ Attributes, JarFile }
-
 import scala.language.reflectiveCalls
 
-class ClassPathBuilder {
+class ClassPathBuilder extends LazyLogging {
+
   import ClassPathBuilder._
 
   private[this] val classpath = new ArrayBuffer[String]
@@ -101,19 +103,19 @@ class ClassPathBuilder {
               // classpath entries are usually relative to the jar
               if (new File(n).exists) n else new File(parent, n).getPath
             }
-            debug("Found manifest classpath values %s in ", answer, f)
+            logger.debug("Found manifest classpath values %s in ", answer, f)
           }
         }
       } catch {
         case e: Exception => // ignore any errors probably due to non-jar
-          debug(e, "Ignoring exception trying to open jar file: %s", f)
+          logger.debug(s"Ignoring exception trying to open jar file: $f", e)
       }
     }
     answer
   }
 }
 
-private object ClassPathBuilder extends Log {
+private object ClassPathBuilder extends LazyLogging {
 
   type AntLikeClassLoader = {
     def getClasspath: String
@@ -154,7 +156,7 @@ private object ClassPathBuilder extends Log {
       cp.split(File.pathSeparator).toIndexedSeq
 
     case _ =>
-      warn("Cannot introspect on class loader: %s of type %s", classLoader, classLoader.getClass.getCanonicalName)
+      logger.warn("Cannot introspect on class loader: %s of type %s", classLoader, classLoader.getClass.getCanonicalName)
       val parent = classLoader.getParent
       if (parent != null && parent != classLoader) getClassPathFrom(parent)
       else Nil

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/IOUtil.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/IOUtil.scala
@@ -18,16 +18,15 @@
 
 package org.fusesource.scalate.util
 
+import slogging.LazyLogging
+
 import java.io._
 import java.util.zip.{ ZipEntry, ZipInputStream }
 import java.net.URL
-import scala.util.parsing.input.{ Position, OffsetPosition }
-
+import scala.util.parsing.input.{ OffsetPosition, Position }
 import scala.language.implicitConversions
 
-object IOUtil {
-
-  val log = Log(getClass); import log._
+object IOUtil extends LazyLogging {
 
   class InvalidDirectiveException(directive: String, pos: Position) extends RuntimeException(directive + " at " + pos, null)
 
@@ -228,7 +227,7 @@ object IOUtil {
         } else {
           val name = entry.getName
           if (!entry.isDirectory && filter(entry)) {
-            debug("processing resource: %s", name)
+            logger.debug(s"processing resource: $name")
             val file = new File(outputDir.getCanonicalPath + "/" + name)
             file.getParentFile.mkdirs
             val bos = new FileOutputStream(file)

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/Logging.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/Logging.scala
@@ -24,181 +24,182 @@ import java.util.concurrent.atomic.AtomicLong
 
 /**
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
- */
-object Log {
-  def apply(name: String): Log = new Log {
-    override lazy val log = LoggerFactory.getLogger(name)
-  }
-  def apply(clazz: Class[_]): Log = apply(clazz.getName.replace("$", "#").stripSuffix("#"))
-  def apply(clazz: Class[_], suffix: String): Log = apply(clazz.getName.replace("$", "#").stripSuffix("#") + "." + suffix)
-
-  val exception_id_generator = new AtomicLong(System.currentTimeMillis)
-  def next_exception_id = exception_id_generator.incrementAndGet.toHexString
-}
-
-/**
+ * object Log {
+ * def apply(name: String): Log = new Log {
+ * override lazy val log = LoggerFactory.getLogger(name)
+ * }
+ * def apply(clazz: Class[_]): Log = apply(clazz.getName.replace("$", "#").stripSuffix("#"))
+ * def apply(clazz: Class[_], suffix: String): Log = apply(clazz.getName.replace("$", "#").stripSuffix("#") + "." + suffix)
+ *
+ * val exception_id_generator = new AtomicLong(System.currentTimeMillis)
+ * def next_exception_id = exception_id_generator.incrementAndGet.toHexString
+ * }
+ *
+ * /**
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
- */
-trait Log {
-  import Log._
-
-  lazy val log = LoggerFactory.getLogger(getClass.getName.replace("$", "#").stripSuffix("#"))
-
-  private def with_throwable(e: Throwable)(func: => Unit) = {
-    if (e != null) {
-      val stack_ref = if (log.isDebugEnabled) {
-        val id = next_exception_id
-        MDC.put("stackref", id.toString)
-        Some(id)
-      } else {
-        None
-      }
-      func
-      stack_ref.foreach { id =>
-        log.debug("stack trace: " + id, e)
-        MDC.remove("stackref")
-      }
-    } else {
-      func
-    }
-  }
-
-  private def format(message: String, args: Seq[Any]) = {
-    if (args.isEmpty) {
-      message
-    } else {
-      message.format(args.map(_.asInstanceOf[AnyRef]): _*)
-    }
-  }
-
-  def error(m: => String, args: Any*): Unit = {
-    if (log.isErrorEnabled) {
-      log.error(format(m, args.toSeq))
-    }
-  }
-
-  def error(e: Throwable, m: => String, args: Any*): Unit = {
-    if (log.isErrorEnabled) {
-      with_throwable(e) {
-        log.error(format(m, args.toSeq))
-      }
-    }
-  }
-
-  def error(e: Throwable): Unit = {
-    if (log.isErrorEnabled) {
-      with_throwable(e) {
-        log.error(e.getMessage)
-      }
-    }
-  }
-
-  def warn(m: => String, args: Any*): Unit = {
-    if (log.isWarnEnabled) {
-      log.warn(format(m, args.toSeq))
-    }
-  }
-
-  def warn(e: Throwable, m: => String, args: Any*): Unit = {
-    if (log.isWarnEnabled) {
-      with_throwable(e) {
-        log.warn(format(m, args.toSeq))
-      }
-    }
-  }
-
-  def warn(e: Throwable): Unit = {
-    if (log.isWarnEnabled) {
-      with_throwable(e) {
-        log.warn(e.getMessage)
-      }
-    }
-  }
-
-  def info(m: => String, args: Any*): Unit = {
-    if (log.isInfoEnabled) {
-      log.info(format(m, args.toSeq))
-    }
-  }
-
-  def info(e: Throwable, m: => String, args: Any*): Unit = {
-    if (log.isInfoEnabled) {
-      with_throwable(e) {
-        log.info(format(m, args.toSeq))
-      }
-    }
-  }
-
-  def info(e: Throwable): Unit = {
-    with_throwable(e) {
-      if (log.isInfoEnabled) {
-        log.info(e.getMessage)
-      }
-    }
-  }
-
-  def debug(m: => String, args: Any*): Unit = {
-    if (log.isDebugEnabled) {
-      log.debug(format(m, args.toSeq))
-    }
-  }
-
-  def debug(e: Throwable, m: => String, args: Any*): Unit = {
-    if (log.isDebugEnabled) {
-      log.debug(format(m, args.toSeq), e)
-    }
-  }
-
-  def debug(e: Throwable): Unit = {
-    if (log.isDebugEnabled) {
-      log.debug(e.getMessage, e)
-    }
-  }
-
-  def trace(m: => String, args: Any*): Unit = {
-    if (log.isTraceEnabled) {
-      log.trace(format(m, args.toSeq))
-    }
-  }
-
-  def trace(e: Throwable, m: => String, args: Any*): Unit = {
-    if (log.isTraceEnabled) {
-      log.trace(format(m, args.toSeq), e)
-    }
-  }
-
-  def trace(e: Throwable): Unit = {
-    if (log.isTraceEnabled) {
-      log.trace(e.getMessage, e)
-    }
-  }
-
-}
-
-/**
+ * */
+ * trait Log {
+ * import Log._
+ *
+ * lazy val log = LoggerFactory.getLogger(getClass.getName.replace("$", "#").stripSuffix("#"))
+ *
+ * private def with_throwable(e: Throwable)(func: => Unit) = {
+ * if (e != null) {
+ * val stack_ref = if (log.isDebugEnabled) {
+ * val id = next_exception_id
+ * MDC.put("stackref", id.toString)
+ * Some(id)
+ * } else {
+ * None
+ * }
+ * func
+ * stack_ref.foreach { id =>
+ * log.debug("stack trace: " + id, e)
+ * MDC.remove("stackref")
+ * }
+ * } else {
+ * func
+ * }
+ * }
+ *
+ * private def format(message: String, args: Seq[Any]) = {
+ * if (args.isEmpty) {
+ * message
+ * } else {
+ * message.format(args.map(_.asInstanceOf[AnyRef]): _*)
+ * }
+ * }
+ *
+ * def error(m: => String, args: Any*): Unit = {
+ * if (log.isErrorEnabled) {
+ * log.error(format(m, args.toSeq))
+ * }
+ * }
+ *
+ * def error(e: Throwable, m: => String, args: Any*): Unit = {
+ * if (log.isErrorEnabled) {
+ * with_throwable(e) {
+ * log.error(format(m, args.toSeq))
+ * }
+ * }
+ * }
+ *
+ * def error(e: Throwable): Unit = {
+ * if (log.isErrorEnabled) {
+ * with_throwable(e) {
+ * log.error(e.getMessage)
+ * }
+ * }
+ * }
+ *
+ * def warn(m: => String, args: Any*): Unit = {
+ * if (log.isWarnEnabled) {
+ * log.warn(format(m, args.toSeq))
+ * }
+ * }
+ *
+ * def warn(e: Throwable, m: => String, args: Any*): Unit = {
+ * if (log.isWarnEnabled) {
+ * with_throwable(e) {
+ * log.warn(format(m, args.toSeq))
+ * }
+ * }
+ * }
+ *
+ * def warn(e: Throwable): Unit = {
+ * if (log.isWarnEnabled) {
+ * with_throwable(e) {
+ * log.warn(e.getMessage)
+ * }
+ * }
+ * }
+ *
+ * def info(m: => String, args: Any*): Unit = {
+ * if (log.isInfoEnabled) {
+ * log.info(format(m, args.toSeq))
+ * }
+ * }
+ *
+ * def info(e: Throwable, m: => String, args: Any*): Unit = {
+ * if (log.isInfoEnabled) {
+ * with_throwable(e) {
+ * log.info(format(m, args.toSeq))
+ * }
+ * }
+ * }
+ *
+ * def info(e: Throwable): Unit = {
+ * with_throwable(e) {
+ * if (log.isInfoEnabled) {
+ * log.info(e.getMessage)
+ * }
+ * }
+ * }
+ *
+ * def debug(m: => String, args: Any*): Unit = {
+ * if (log.isDebugEnabled) {
+ * log.debug(format(m, args.toSeq))
+ * }
+ * }
+ *
+ * def debug(e: Throwable, m: => String, args: Any*): Unit = {
+ * if (log.isDebugEnabled) {
+ * log.debug(format(m, args.toSeq), e)
+ * }
+ * }
+ *
+ * def debug(e: Throwable): Unit = {
+ * if (log.isDebugEnabled) {
+ * log.debug(e.getMessage, e)
+ * }
+ * }
+ *
+ * def trace(m: => String, args: Any*): Unit = {
+ * if (log.isTraceEnabled) {
+ * log.trace(format(m, args.toSeq))
+ * }
+ * }
+ *
+ * def trace(e: Throwable, m: => String, args: Any*): Unit = {
+ * if (log.isTraceEnabled) {
+ * log.trace(format(m, args.toSeq), e)
+ * }
+ * }
+ *
+ * def trace(e: Throwable): Unit = {
+ * if (log.isTraceEnabled) {
+ * log.trace(e.getMessage, e)
+ * }
+ * }
+ *
+ * }
+ *
+ * /**
  * A Logging trait you can mix into an implementation class without affecting its public API
+ * */
+ * trait Logging {
+ *
+ * protected val log = Log(getClass)
+ *
+ * protected def error(message: => String): Unit = log.error(message)
+ * protected def error(message: => String, e: Throwable): Unit = log.error(e, message)
+ * protected def error(e: Throwable): Unit = log.error(e)
+ *
+ * protected def warn(message: => String): Unit = log.warn(message)
+ * protected def warn(message: => String, e: Throwable): Unit = log.warn(e, message)
+ * protected def warn(e: Throwable): Unit = log.warn(e)
+ *
+ * protected def info(message: => String): Unit = log.info(message)
+ * protected def info(message: => String, e: Throwable): Unit = log.info(e, message)
+ * protected def info(e: Throwable): Unit = log.info(e)
+ *
+ * protected def debug(message: => String): Unit = log.debug(message)
+ * protected def debug(message: => String, e: Throwable): Unit = log.debug(e, message)
+ * protected def debug(e: Throwable): Unit = log.debug(e)
+ *
+ * protected def trace(message: => String): Unit = log.trace(message)
+ * protected def trace(message: => String, e: Throwable): Unit = log.trace(e, message)
+ * protected def trace(e: Throwable): Unit = log.trace(e)
+ * }
+ *
  */
-trait Logging {
-
-  protected val log = Log(getClass)
-
-  protected def error(message: => String): Unit = log.error(message)
-  protected def error(message: => String, e: Throwable): Unit = log.error(e, message)
-  protected def error(e: Throwable): Unit = log.error(e)
-
-  protected def warn(message: => String): Unit = log.warn(message)
-  protected def warn(message: => String, e: Throwable): Unit = log.warn(e, message)
-  protected def warn(e: Throwable): Unit = log.warn(e)
-
-  protected def info(message: => String): Unit = log.info(message)
-  protected def info(message: => String, e: Throwable): Unit = log.info(e, message)
-  protected def info(e: Throwable): Unit = log.info(e)
-
-  protected def debug(message: => String): Unit = log.debug(message)
-  protected def debug(message: => String, e: Throwable): Unit = log.debug(e, message)
-  protected def debug(e: Throwable): Unit = log.debug(e)
-
-  protected def trace(message: => String): Unit = log.trace(message)
-  protected def trace(message: => String, e: Throwable): Unit = log.trace(e, message)
-  protected def trace(e: Throwable): Unit = log.trace(e)
-}

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/Measurements.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/Measurements.scala
@@ -1,7 +1,8 @@
 package org.fusesource.scalate.util
 
+import slogging.LazyLogging
+
 object Measurements {
-  val log = Log(classOf[UnitOfMeasure])
 
   // computer memory/disk sizes
   val gb = UnitOfMeasure("Gb", "Gb")
@@ -28,9 +29,7 @@ object Measurements {
   val amount = UnitOfMeasure("", "", thousand, 1000)
 }
 
-import Measurements.log
-
-case class UnitOfMeasure(unitsName: String, unitName: String, parent: UnitOfMeasure = null, size: Double = 0) {
+case class UnitOfMeasure(unitsName: String, unitName: String, parent: UnitOfMeasure = null, size: Double = 0) extends LazyLogging {
   // we are using null rather than None as it seems a bit easier on the DSL defining the data
   if (parent != null) {
     assert(size != 0, "Unit should never have size of zero if we have a parent!")
@@ -45,7 +44,7 @@ case class UnitOfMeasure(unitsName: String, unitName: String, parent: UnitOfMeas
         apply(text.toDouble, defaultExpression)
       } catch {
         case e: Exception =>
-          log.debug("Could not convert " + text + " to a number: " + e, e)
+          logger.debug("Could not convert " + text + " to a number: " + e, e)
           defaultExpression
       }
     case _ => defaultExpression

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/Objects.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/Objects.scala
@@ -17,14 +17,15 @@
  */
 package org.fusesource.scalate.util
 
+import slogging.LazyLogging
+
 import java.lang.reflect.Constructor
 import scala.reflect.ClassTag
 
 /**
  * Helper object for working with objects using reflection
  */
-object Objects {
-  val log = Log(getClass); import log._
+object Objects extends LazyLogging {
 
   /**
    * A helper method to return a non null value or the default value if it is null
@@ -67,7 +68,7 @@ object Objects {
       val answer = if (args.isEmpty) {
         clazz.getConstructor().newInstance()
       } else {
-        debug("About to call constructor: %S on %s with args: %s", c, clazz.getName, args.toList)
+        logger.debug("About to call constructor: %S on %s with args: %s", c, clazz.getName, args.toList)
         c.newInstance(args: _*)
       }
       answer.asInstanceOf[T]

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/Resource.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/Resource.scala
@@ -17,6 +17,8 @@
  */
 package org.fusesource.scalate.util
 
+import slogging.StrictLogging
+
 import io.Source
 import java.io._
 import java.net.{ URISyntaxException, URL }
@@ -153,9 +155,8 @@ case class FileResource(file: File, uri: String) extends WriteableResource {
   def relativeUri(root: File) = Files.relativeUri(root, file)
 }
 
-object URLResource extends Log
-case class URLResource(url: URL) extends WriteableResource {
-  import URLResource._
+case class URLResource(url: URL) extends WriteableResource with StrictLogging {
+
   def uri = url.toExternalForm
 
   lazy val connection = url.openConnection
@@ -181,7 +182,7 @@ case class URLResource(url: URL) extends WriteableResource {
       } catch {
         case e: ThreadDeath => throw e
         case e: VirtualMachineError => throw e
-        case e: Exception => debug(e, "While converting " + url + " to a File I caught: " + e)
+        case e: Exception => logger.debug(s"While converting $url to a File I caught: $e", e)
       }
     }
     if (f != null && f.exists && f.isFile) {

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/ResourceLoader.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/ResourceLoader.scala
@@ -20,16 +20,14 @@ package org.fusesource.scalate.util
 import java.net.URI
 import java.io.File
 import Resource._
-
-object ResourceLoader extends Log
-import ResourceLoader._
+import slogging.LazyLogging
 
 /**
  * A strategy for loading [[Resource]] instances
  *
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
-trait ResourceLoader {
+trait ResourceLoader extends LazyLogging {
   val pageFileEncoding = "UTF-8"
 
   def resource(uri: String): Option[Resource]
@@ -49,7 +47,7 @@ trait ResourceLoader {
 
   def resourceOrFail(uri: String): Resource = resource(uri) match {
     case Some(r) =>
-      debug("found resource: " + r)
+      logger.debug("found resource: " + r)
       r
     case _ =>
       throw createNotFoundException(uri)
@@ -58,10 +56,10 @@ trait ResourceLoader {
   protected def createNotFoundException(uri: String) = new ResourceNotFoundException(uri)
 }
 
-case class FileResourceLoader(sourceDirectories: Iterable[File] = Iterable.empty) extends ResourceLoader {
+case class FileResourceLoader(sourceDirectories: Iterable[File] = Iterable.empty) extends ResourceLoader with LazyLogging {
 
   def resource(uri: String): Option[Resource] = {
-    debug("Trying to load uri: " + uri)
+    logger.debug("Trying to load uri: " + uri)
 
     if (uri != null) {
       val file = toFile(uri)

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/SourceMap.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/SourceMap.scala
@@ -17,12 +17,13 @@
  */
 package org.fusesource.scalate.util
 
+import slogging.StrictLogging
+
 import java.util.ArrayList
 import java.io._
 import scala.util.parsing.combinator._
 import scala.util.parsing.input._
 import collection.JavaConverters._
-
 import scala.language.reflectiveCalls
 
 /**
@@ -238,7 +239,8 @@ class SourceMapStratum(val name: String) {
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  * @author Shawn Bayern
  */
-class SourceMap {
+class SourceMap extends StrictLogging {
+
   private[this] var outputFileName: String = null
   private[this] var doEmbedded = true
   private[this] var embedded = List[String]()
@@ -424,9 +426,7 @@ object SourceMapInstaller {
    */
   val SOURCE_DEBUG_EXTENSION_MAX_SIZE = Integer.getInteger("SOURCE_DEBUG_EXTENSION_MAX_SIZE", 65535).intValue
 
-  object Writer extends Log
-  class Writer(val orig: Array[Byte], val sourceDebug: String) {
-    import Writer._
+  class Writer(val orig: Array[Byte], val sourceDebug: String) extends StrictLogging {
 
     val bais = new ByteArrayInputStream(orig)
     val dis = new DataInputStream(bais)
@@ -517,7 +517,7 @@ object SourceMapInstaller {
           case 1 =>
             var len: Int = copyShort & 0xFFFF
             if (len < 0) {
-              warn("Index is " + len + " for constantPoolCount: " + constantPoolCount + " nothing to write")
+              logger.warn("Index is " + len + " for constantPoolCount: " + constantPoolCount + " nothing to write")
               len = 0
             }
             val data = new Array[Byte](len)
@@ -572,7 +572,6 @@ object SourceMapInstaller {
     }
   }
 
-  object Reader extends Log
   class Reader(val orig: Array[Byte]) {
 
     val bais = new ByteArrayInputStream(orig)

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/XmlHelper.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/XmlHelper.scala
@@ -17,6 +17,8 @@
  */
 package org.fusesource.scalate.util
 
+import slogging.StrictLogging
+
 import scala.xml._
 import scala.xml.parsing.ConstructingParser
 import scala.io.Source
@@ -25,15 +27,14 @@ import scala.io.Source
  * @version $Revision : 1.1 $
  */
 
-object XmlHelper {
-  val log = Log(getClass); import log._
+object XmlHelper extends StrictLogging {
 
   /**
    * Parsers some markup which might not be a single Xml document
    * by wrapping it in a root XML element first
    */
   def textToNodeSeq(text: String): NodeSeq = {
-    debug("parsing markup: " + text)
+    logger.debug("parsing markup: " + text)
 
     val src = Source.fromString("<p>" + text + "</p>")
 

--- a/scalate-util/src/test/scala/org/fusesource/scalate/FunSuiteSupport.scala
+++ b/scalate-util/src/test/scala/org/fusesource/scalate/FunSuiteSupport.scala
@@ -18,18 +18,17 @@
 package org.fusesource.scalate
 
 import java.io.File
-
-import org.fusesource.scalate.util.Log
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{ BeforeAndAfterAllConfigMap, ConfigMap }
 import org.scalatest.funsuite.AnyFunSuite
+import slogging.StrictLogging
 
 /**
  * @version $Revision : 1.1 $
  */
 @RunWith(classOf[JUnitRunner])
-abstract class FunSuiteSupport extends AnyFunSuite with Log with BeforeAndAfterAllConfigMap {
+abstract class FunSuiteSupport extends AnyFunSuite with StrictLogging with BeforeAndAfterAllConfigMap {
 
   protected var _basedir = "."
 
@@ -43,7 +42,7 @@ abstract class FunSuiteSupport extends AnyFunSuite with Log with BeforeAndAfterA
       case Some(basedir) => basedir.toString
       case _ => System.getProperty("basedir", ".")
     }
-    debug("using basedir: %s", _basedir)
+    logger.debug("using basedir: %s", _basedir)
   }
 
   def assertType(anyRef: AnyRef, expectedClass: Class[_]): Unit = {

--- a/scalate-util/src/test/scala/org/fusesource/scalate/util/DisplaySourceDebugInfo.scala
+++ b/scalate-util/src/test/scala/org/fusesource/scalate/util/DisplaySourceDebugInfo.scala
@@ -17,6 +17,8 @@
  */
 package org.fusesource.scalate.util
 
+import slogging.StrictLogging
+
 import _root_.java.io.File
 
 /**
@@ -24,17 +26,17 @@ import _root_.java.io.File
  *
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
-object DisplaySourceDebugInfo extends Log {
+object DisplaySourceDebugInfo extends StrictLogging {
 
   def main(args: Array[String]) = {
     val fileName = if (args.size > 0) args(0) else "scalate-sample/src/main/webapp/WEB-INF/_scalate/classes/scaml/$_scalate_$missingAttribute_scaml$.class"
-    log.info("Loading class file: " + fileName)
+    logger.info("Loading class file: " + fileName)
 
     val file = new File(fileName)
     if (file.exists) {
-      log.info(SourceMapInstaller.load(file))
+      logger.info(SourceMapInstaller.load(file))
     } else {
-      log.warn("ERROR: " + file + " does not exist!")
+      logger.warn("ERROR: " + file + " does not exist!")
     }
   }
 

--- a/scalate-util/src/test/scala/org/fusesource/scalate/util/FileTest.scala
+++ b/scalate-util/src/test/scala/org/fusesource/scalate/util/FileTest.scala
@@ -32,7 +32,7 @@ class FileTest extends FunSuiteSupport {
     val f2: File = sources
     assertResult(true) { f2.exists }
 
-    info("created file: " + sources.file)
+    logger.info("created file: " + sources.file)
   }
 
   test("getting text of a file") {
@@ -41,7 +41,7 @@ class FileTest extends FunSuiteSupport {
     val t = file.text.trim
     assertResult("hello world!") { t }
 
-    info("Loaded file: " + file + " as text: " + t)
+    logger.info("Loaded file: " + file + " as text: " + t)
   }
 
   test("getting text of a file with include") {
@@ -51,7 +51,7 @@ class FileTest extends FunSuiteSupport {
 
     assertResult("My header 1\nhello world!") { t }
 
-    info("Loaded file: " + file + " as text: " + t)
+    logger.info("Loaded file: " + file + " as text: " + t)
   }
 
   test("getting text of a file with two includes") {
@@ -61,7 +61,7 @@ class FileTest extends FunSuiteSupport {
 
     assertResult("My header 1\nMy Second Header\ngood bye world!") { t }
 
-    info("Loaded file: " + file + " as text: " + t)
+    logger.info("Loaded file: " + file + " as text: " + t)
   }
 
   test("getting text of a file with include in the middle") {
@@ -71,7 +71,7 @@ class FileTest extends FunSuiteSupport {
 
     assertResult("hello world!\nMy header 1\nAFTER WORLD!") { t }
 
-    info("Loaded file: " + file + " as text: " + t)
+    logger.info("Loaded file: " + file + " as text: " + t)
   }
 
   test("getting text of a file with nested include") {
@@ -81,13 +81,13 @@ class FileTest extends FunSuiteSupport {
 
     assertResult("My header 1\nhello world!\nEnd of 2012 is here") { t }
 
-    info("Loaded file: " + file + " as text: " + t)
+    logger.info("Loaded file: " + file + " as text: " + t)
   }
 
   test("working with names") {
     val file = baseDir / "foo.txt"
 
-    info("name: " + file.name + " extension: " + file.extension)
+    logger.info("name: " + file.name + " extension: " + file.extension)
 
     assertResult("txt", "extension") { file.extension }
     assertResult("foo", "nameDropExtension") { file.nameDropExtension }
@@ -126,7 +126,7 @@ class FileTest extends FunSuiteSupport {
 
   def assertNameSplit(name: String, expectedName: String, expectedExt: String): Unit = {
     test("splitName: " + name) {
-      info("Name " + name + " -> name: " + Files.dropExtension(name) + " extension: " + Files.extension(name))
+      logger.info("Name " + name + " -> name: " + Files.dropExtension(name) + " extension: " + Files.extension(name))
 
       assertResult(expectedExt, "extension") { Files.extension(name) }
       assertResult(expectedName, "name without extension") { Files.dropExtension(name) }

--- a/scalate-util/src/test/scala/org/fusesource/scalate/util/LogTest.scala
+++ b/scalate-util/src/test/scala/org/fusesource/scalate/util/LogTest.scala
@@ -20,6 +20,7 @@ package util
 
 import org.scalatest.matchers.should.Matchers
 
+/*
 object LogTest
 
 class LogTest extends FunSuiteSupport with Matchers {
@@ -47,3 +48,4 @@ class LogTest extends FunSuiteSupport with Matchers {
     log.log.getName should equal("org.fusesource.scalate.util.LogTest#InnerObject.postfix")
   }
 }
+ */

--- a/scalate-util/src/test/scala/org/fusesource/scalate/util/ObjectsTest.scala
+++ b/scalate-util/src/test/scala/org/fusesource/scalate/util/ObjectsTest.scala
@@ -19,8 +19,9 @@ package org.fusesource.scalate
 package util
 
 import Objects._
+import slogging.StrictLogging
 
-class ObjectsTest extends FunSuiteSupport {
+class ObjectsTest extends FunSuiteSupport with StrictLogging {
 
   test("inject no params") {
     val a = assertInstantiate(classOf[NoParams])
@@ -33,7 +34,7 @@ class ObjectsTest extends FunSuiteSupport {
   protected def assertInstantiate[T](clazz: Class[T], injectValues: List[AnyRef] = List()): T = {
     val answer = instantiate(clazz, injectValues)
     assert(answer != null, "Should have instantiated an instance of " + clazz.getName)
-    debug("Instantiated: " + answer)
+    logger.debug("Instantiated: " + answer)
     answer
 
   }
@@ -50,4 +51,3 @@ case class StringParam(name: String)
 class NoParams {
   val value = "Hello"
 }
-

--- a/scalate-war/src/test/scala/org/fusesource/scalate/console/EditLinkTest.scala
+++ b/scalate-war/src/test/scala/org/fusesource/scalate/console/EditLinkTest.scala
@@ -22,9 +22,10 @@ import _root_.org.fusesource.scalate.util._
 import _root_.org.junit.runner.RunWith
 import _root_.org.scalatestplus.junit.JUnitRunner
 import org.scalatest.funsuite.AnyFunSuite
+import slogging.StrictLogging
 
 @RunWith(classOf[JUnitRunner])
-class EditLinkTest extends AnyFunSuite with Log {
+class EditLinkTest extends AnyFunSuite with StrictLogging {
 
   val file = "src/test/scala/org/fusesource/scalate/console/EditLinkTest.scala"
 
@@ -42,7 +43,7 @@ class EditLinkTest extends AnyFunSuite with Log {
     // lets put a render context in scope
     RenderContext.using(new DefaultRenderContext(file, new TemplateEngine())) {
       val link = EditLink.editLink(file)( /*"Edit file"*/ ())
-      log.info(name + " link = " + link)
+      logger.info(name + " link = " + link)
     }
   }
 }

--- a/scalate-war/src/test/scala/org/fusesource/scalate/sample/ArchetypeTest.scala
+++ b/scalate-war/src/test/scala/org/fusesource/scalate/sample/ArchetypeTest.scala
@@ -34,7 +34,7 @@ class ArchetypeTest extends FunSuiteSupport {
   test("use tableView archetype") {
     val output = engine.layout("/WEB-INF/scalate/archetypes/views/index/tableView.ssp", Map("resourceType" -> classOf[Person])).trim
 
-    log.info("Generated SSP:")
-    log.info(output)
+    logger.info("Generated SSP:")
+    logger.info(output)
   }
 }

--- a/scalate-website/ext/scalate/Boot.scala
+++ b/scalate-website/ext/scalate/Boot.scala
@@ -48,7 +48,7 @@ class Boot(engine: TemplateEngine) {
       // lets add the confluence macros...
       ConfluenceLanguageExtensions.extensions ++= List(ExpressionTag("project_version", () => project_version))
 
-      info("Bootstrapped website gen for: %s", project_name)
+      logger.info("Bootstrapped website gen for: %s", project_name)
     }
   }
 }

--- a/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/AttributesBlock.scala
+++ b/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/AttributesBlock.scala
@@ -18,19 +18,17 @@
 package org.fusesource.scalate
 package wikitext
 
-import util.Log
-
-object AttributesTag extends Log; import AttributesTag._
+import slogging.StrictLogging
 
 /**
  * Allows Scalate attributes to be defined inside a confluence template.
  *
  * For example  {attributes:layout=foo.scaml } to change the layout
  */
-class AttributesTag extends AbstractConfluenceTagSupport("attributes") {
+class AttributesTag extends AbstractConfluenceTagSupport("attributes") with StrictLogging {
 
   def setOption(key: String, value: String) = {
-    debug("{attributes} setting %s to %s", key, value)
+    logger.debug("{attributes} setting %s to %s", key, value)
     val context = RenderContext()
     context.attributes(key) = value
   }
@@ -38,4 +36,3 @@ class AttributesTag extends AbstractConfluenceTagSupport("attributes") {
   def doTag() = {
   }
 }
-

--- a/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/ChildrenTag.scala
+++ b/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/ChildrenTag.scala
@@ -19,17 +19,17 @@ package org.fusesource.scalate
 package wikitext
 
 import StringConverter._
+import slogging.StrictLogging
 
 import java.io.File
 import xml.NodeSeq
-import util.{ Log, Files }
+import util.Files
 
-object ChildrenTag extends Log
 /**
  * Implements the **children** macro in confluence
  */
-class ChildrenTag extends AbstractConfluenceTagSupport("children") {
-  import ChildrenTag._
+class ChildrenTag extends AbstractConfluenceTagSupport("children") with StrictLogging {
+
   var page: Option[String] = None
   var depth = 1
   var all = false
@@ -53,12 +53,12 @@ class ChildrenTag extends AbstractConfluenceTagSupport("children") {
           {
             files.map {
               f =>
-                debug("{children} processing file '%s'", f)
+                logger.debug("{children} processing file '%s'", f)
                 if (f.isFile) {
                   val title = Pages.title(f)
                   val link = Files.relativeUri(rootDir, new File(f.getParentFile, Files.dropExtension(f) + ".html"))
                   val child = new File(f.getParentFile, Files.dropExtension(f))
-                  debug("{children} checking child '%s'", child)
+                  logger.debug("{children} checking child '%s'", child)
                   val dirXml = if (child.isDirectory) {
                     showChildren(rootDir, child, level + 1)
                   } else {
@@ -85,18 +85,18 @@ class ChildrenTag extends AbstractConfluenceTagSupport("children") {
     val pageUri = page.getOrElse(Files.dropExtension(pageName))
     SwizzleLinkFilter.findWikiFile(pageUri) match {
       case Some(file) =>
-        info("{children} now going to iterate from file '%s'", file)
+        logger.info("{children} now going to iterate from file '%s'", file)
         val rootDir = file.getParentFile
         val dir = new File(rootDir, Files.dropExtension(file))
         if (!dir.exists) {
-          warn("{children} cannot find directory: %s", dir)
+          logger.warn("{children} cannot find directory: %s", dir)
         } else {
           //context << showChildren(rootDir, dir, 1)
           builder.charactersUnescaped(showChildren(rootDir, dir, 1).toString)
         }
 
       case _ =>
-        warn("Could not find wiki file for page '%s'", pageUri)
+        logger.warn("Could not find wiki file for page '%s'", pageUri)
     }
   }
 }

--- a/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/HtmlBlocks.scala
+++ b/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/HtmlBlocks.scala
@@ -18,11 +18,12 @@
 package org.fusesource.scalate.wikitext
 
 import org.eclipse.mylyn.wikitext.core.parser.DocumentBuilder.BlockType
+
 import collection.mutable.ListBuffer
-import java.util.regex.{ Pattern, Matcher }
-import org.eclipse.mylyn.internal.wikitext.confluence.core.block.{ ParameterizedBlock, AbstractConfluenceDelimitedBlock }
-import org.eclipse.mylyn.wikitext.core.parser.{ TableRowAttributes, TableAttributes, TableCellAttributes, Attributes }
-import org.fusesource.scalate.util.Log
+import java.util.regex.{ Matcher, Pattern }
+import org.eclipse.mylyn.internal.wikitext.confluence.core.block.{ AbstractConfluenceDelimitedBlock, ParameterizedBlock }
+import org.eclipse.mylyn.wikitext.core.parser.{ Attributes, TableAttributes, TableCellAttributes, TableRowAttributes }
+import slogging.StrictLogging
 
 class HtmlBlock extends AbstractConfluenceDelimitedBlock("html") {
 
@@ -255,15 +256,14 @@ class CenterBlock extends AbstractNestedBlock("center") {
     Blocks.setOption(attributes, key, value)
 }
 
-object Blocks {
-  val log = Log(getClass); import log._
+object Blocks extends StrictLogging {
 
   def unknownAttribute(key: String, value: String): Unit = {
-    warn("Unknown attribute '%s' with value: %s", key, value)
+    logger.warn("Unknown attribute '%s' with value: %s", key, value)
   }
 
   def unknownOption(option: String) = {
-    warn("Not sure how to set the option: %s", option)
+    logger.warn("Not sure how to set the option: %s", option)
   }
 
   def setOption(attributes: Attributes, key: String, value: String) = {

--- a/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/IncludeTag.scala
+++ b/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/IncludeTag.scala
@@ -18,16 +18,14 @@
 package org.fusesource.scalate
 package wikitext
 
-import util.{ Log, Files }
-
-object IncludeTag extends Log
+import slogging.StrictLogging
+import util.Files
 
 /**
  * Implements the "include" macro
  */
-class IncludeTag extends AbstractConfluenceTagSupport("include") {
+class IncludeTag extends AbstractConfluenceTagSupport("include") with StrictLogging {
 
-  import IncludeTag._
   var uri: String = _
 
   override def setOption(option: String) = {
@@ -40,7 +38,7 @@ class IncludeTag extends AbstractConfluenceTagSupport("include") {
   def doTag() = {
     val realUri = SwizzleLinkFilter.findWikiFileUri(uri).getOrElse(uri)
 
-    debug("{include} is now going to include URI '%s' found to map to '%s'", uri, realUri)
+    logger.debug("{include} is now going to include URI '%s' found to map to '%s'", uri, realUri)
 
     val context = RenderContext()
     val ex = Files.extension(realUri)
@@ -54,10 +52,10 @@ class IncludeTag extends AbstractConfluenceTagSupport("include") {
         context.
           engine.resourceLoader.resource(realUri) match {
             case Some(r) =>
-              warn("Using non-template or wiki markup  '%s' from {include:%s}", realUri, uri)
+              logger.warn("Using non-template or wiki markup  '%s' from {include:%s}", realUri, uri)
               r.text
             case _ =>
-              warn("Could not find include '%s' from {include:%s}", realUri, uri)
+              logger.warn("Could not find include '%s' from {include:%s}", realUri, uri)
               ""
           }
 

--- a/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/PygmentsBlock.scala
+++ b/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/PygmentsBlock.scala
@@ -20,18 +20,22 @@ package org.fusesource.scalate.wikitext
 import org.eclipse.mylyn.wikitext.core.parser.Attributes
 import org.eclipse.mylyn.wikitext.core.parser.DocumentBuilder.BlockType
 import org.eclipse.mylyn.internal.wikitext.confluence.core.block.AbstractConfluenceDelimitedBlock
+
 import java.lang.String
 import collection.mutable.ListBuffer
 import org.fusesource.scalate.util.Threads._
+
 import util.parsing.input.CharSequenceReader
 import util.parsing.combinator.RegexParsers
 import org.fusesource.scalate.support.RenderHelper
 import org.fusesource.scalate._
 import org.fusesource.scalate.filter.Filter
-import java.io.{ File, ByteArrayInputStream, ByteArrayOutputStream }
-import util.{ Files, Log, IOUtil }
+import slogging.StrictLogging
 
-object Pygmentize extends Log with Filter with TemplateEngineAddOn {
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, File }
+import util.{ Files, IOUtil }
+
+object Pygmentize extends StrictLogging with Filter with TemplateEngineAddOn {
 
   /**
    * Add the markdown filter to the template engine.
@@ -65,14 +69,14 @@ object Pygmentize extends Log with Filter with TemplateEngineAddOn {
         None
       } else {
         val output = new String(out.toByteArray).trim
-        debug("Pygmentize installed: " + output)
+        logger.debug("Pygmentize installed: " + output)
         val version = output.split("[ ,]")(2)
 
         Some(version)
       }
     } catch {
       case e: Exception =>
-        debug(e, "Failed to start pygmentize: " + e)
+        logger.debug(s"Failed to start pygmentize: $e", e)
         None
     }
   }

--- a/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/SwizzleLinkFilter.scala
+++ b/scalate-wikitext/src/main/scala/org/fusesource/scalate/wikitext/SwizzleLinkFilter.scala
@@ -20,9 +20,11 @@ package wikitext
 
 import org.fusesource.scalate.filter.Filter
 import org.fusesource.scalate.support.Links
+
 import java.io.File
-import util.{ Log, IOUtil, Files }
+import util.{ Files, IOUtil }
 import IOUtil._
+import slogging.StrictLogging
 
 /**
  * Converts links used in wiki notation to find the template or wiki markup files on the file system.
@@ -33,15 +35,13 @@ import IOUtil._
  */
 case class SwizzleLinkFilter(
   sourceDirectories: Iterable[File],
-  extensions: Set[String]) extends Filter {
-
-  import SwizzleLinkFilter._
+  extensions: Set[String]) extends Filter with StrictLogging {
 
   /**
    * Lets fix up any links which are local and do notcontain a file extension
    */
   def filter(context: RenderContext, html: String) = {
-    debug("Transforming links with " + this)
+    logger.debug("Transforming links with " + this)
     linkRegex.replaceAllIn(html, {
       // for some reason we don't just get the captured group - no idea why. Instead we get...
       //
@@ -78,7 +78,7 @@ case class SwizzleLinkFilter(
     val name1 = link.stripPrefix("/").toLowerCase
     val name2 = name1.replace(' ', '-')
 
-    info("Looking for files matching %s from %s", name2, requestUri)
+    logger.info("Looking for files matching %s from %s", name2, requestUri)
 
     def matchesName(f: File) = {
       val n = f.nameDropExtension.toLowerCase
@@ -125,7 +125,7 @@ case class SwizzleLinkFilter(
   protected val linkRegex = "(?i)<(?>link|a|img|script)[^>]*?(?>href|src)\\s*?=\\s*?(\\\".*?\\\"|'.*?')[^>]*?".r
 }
 
-object SwizzleLinkFilter extends Log {
+object SwizzleLinkFilter {
   def apply(renderContext: RenderContext): SwizzleLinkFilter = apply(renderContext.engine)
 
   def apply(te: TemplateEngine): SwizzleLinkFilter = {

--- a/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/AbstractConfluenceTest.scala
+++ b/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/AbstractConfluenceTest.scala
@@ -28,12 +28,12 @@ abstract class AbstractConfluenceTest extends FunSuiteSupport {
   val filter = ConfluenceFilter
 
   protected def renderConfluence(source: String): String = {
-    debug("Converting: %s", source)
+    logger.debug("Converting: %s", source)
     val context = new DefaultRenderContext("foo.html", new TemplateEngine())
     val actual = filter.filter(context, source)
-    info("Generated: %s", actual)
+    logger.info("Generated: %s", actual)
 
-    info(actual)
+    logger.info(actual)
     actual
   }
 

--- a/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/ConfluenceTest.scala
+++ b/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/ConfluenceTest.scala
@@ -17,9 +17,11 @@
  */
 package org.fusesource.scalate.wikitext
 
+import slogging.StrictLogging
+
 import java.io.File
 
-class ConfluenceTest extends AbstractConfluenceTest {
+class ConfluenceTest extends AbstractConfluenceTest with StrictLogging {
 
   test("parse confluence wiki") {
     assertFilter(
@@ -61,7 +63,7 @@ END
 
     }
   } else {
-    warn("Pygmentize not installed so ignoring the tests")
+    logger.warn("Pygmentize not installed so ignoring the tests")
   }
 
 }

--- a/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/Main.scala
+++ b/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/Main.scala
@@ -18,9 +18,9 @@
 package org.fusesource.scalate
 package wikitext
 
-import org.fusesource.scalate.util.Log
+import slogging.StrictLogging
 
-object Main extends Log {
+object Main extends StrictLogging {
 
   def main(args: Array[String]): Unit = {
     for (a <- args) {
@@ -31,6 +31,6 @@ object Main extends Log {
   def parseFile(name: String): Unit = {
     val engine = new TemplateEngine
     val output = engine.layout(TemplateSource.fromFile(name))
-    log.info(output)
+    logger.info(output)
   }
 }

--- a/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/SnippetsTest.scala
+++ b/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/SnippetsTest.scala
@@ -134,7 +134,7 @@ h1. Snippet with id
       }
     }
   } else {
-    warn("Pygmentize not installed so ignoring the tests")
+    logger.warn("Pygmentize not installed so ignoring the tests")
   }
 
   test("URL prefix handling") {

--- a/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/SwizzleLinkFilterTest.scala
+++ b/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/SwizzleLinkFilterTest.scala
@@ -72,8 +72,8 @@ class SwizzleLinkFilterTest extends FunSuiteSupport {
       val context = new DefaultRenderContext("foo.html", new TemplateEngine)
       val answer = transformer.filter(context, html)
 
-      info("converted " + html)
-      info("into: " + answer)
+      logger.info("converted " + html)
+      logger.info("into: " + answer)
 
       assertResult(expected) { answer }
     }

--- a/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/TextileTest.scala
+++ b/scalate-wikitext/src/test/scala/org/fusesource/scalate/wikitext/TextileTest.scala
@@ -25,12 +25,12 @@ class TextileTest extends FunSuiteSupport {
   val filter = TextileFilter
 
   protected def renderTextile(source: String): String = {
-    debug("Converting: " + source)
+    logger.debug("Converting: " + source)
     val context = new DefaultRenderContext("foo.textile", new TemplateEngine())
     val actual = filter.filter(context, source)
-    info("Generated: " + actual)
+    logger.info("Generated: " + actual)
 
-    info(actual)
+    logger.info(actual)
     actual
   }
 


### PR DESCRIPTION
This PR is part of the greater effort to [port to Scala-JS](https://github.com/scalate/scalate/pull/307).
The current logging infrastructure is not compatible with Scala-JS, so this PR replaces the SLF4J-based logging with [slogging](https://github.com/jokade/slogging/).

