### PR TITLE
Removed deprecated settings

### DIFF
--- a/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/JRuby.scala
+++ b/scalate-jruby/src/main/scala/org/fusesource/scalate/jruby/JRuby.scala
@@ -13,9 +13,6 @@ class JRuby extends Log {
   var container = new ScriptingContainer(LocalContextScope.SINGLETON)
   container.setCompileMode(RubyInstanceConfig.CompileMode.JIT)
 
-  RubyInstanceConfig.FASTEST_COMPILE_ENABLED = true
-  RubyInstanceConfig.FASTSEND_COMPILE_ENABLED = true
-
   def run(scriptlet: String*): Either[(Throwable, String), AnyRef] = this.synchronized {
     val errors: StringWriter = new StringWriter
     try {


### PR DESCRIPTION
From JRuby 9.3.0.0, the following settings are deprecated
and cannot be changed to 'false'.

RubyInstanceConfig.FASTEST_COMPILE_ENABLED
RubyInstanceConfig.FASTSEND_COMPILE_ENABLED