### PR TITLE
Recursively loads the classpath of the parent class loader

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "4.2.4")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
+addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")

--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassPathBuilder.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassPathBuilder.scala
@@ -151,6 +151,7 @@ private object ClassPathBuilder extends Log {
     }
   }
 
+  //  FIXME: Rewrite to null safe in next update
   //  @tailrec
   //  def getClassPathFrom(optionalClassLoader: Option[ClassLoader], result: mutable.Builder[String, Set[String]] = Set.newBuilder[String]): Set[String] = {
   //    val next = optionalClassLoader.flatMap {

--- a/scalate-util/src/test/scala/org/fusesource/scalate/util/ClassPathBuilderTest.scala
+++ b/scalate-util/src/test/scala/org/fusesource/scalate/util/ClassPathBuilderTest.scala
@@ -20,7 +20,8 @@ package org.fusesource.scalate.util
 import _root_.org.fusesource.scalate.FunSuiteSupport
 
 import java.io.File
-import java.net.{URL, URLClassLoader}
+import java.net.{ URL, URLClassLoader }
+import scala.util.Try
 
 class ClassPathBuilderTest extends FunSuiteSupport {
   import ClassPathBuilderTest._
@@ -125,17 +126,18 @@ class ClassPathBuilderTest extends FunSuiteSupport {
 
     val expectFiles = Seq(
       ValidChildClassLoader.getClasspath,
-      ValidAntLikeClassLoader.getClasspath
-    )
+      ValidAntLikeClassLoader.getClasspath)
     builder.classPath.split(":").map { path =>
       assert(expectFiles.contains(new File(path).getCanonicalPath))
     }
   }
 
-  def assertFiles(actualPath: String, expectedPath: String) = {
+  def assertFiles(actualPath: String, expectedPath: String) = Try {
     val actualFile = new File(actualPath)
     val expectedFile = new File(expectedPath)
     assert(actualFile.getCanonicalPath === expectedFile.getCanonicalPath)
+  }.getOrElse {
+    assert(actualPath === expectedPath)
   }
 }
 


### PR DESCRIPTION
- https://github.com/scalate/scalate/issues/405


When running ssp compilation from the sbt console, a compatibility error occurs when writing a process in the template that may refer to a symbol in scala-reflect

This is because the configuration of the classloader has changed due to the sbt update, and may occur in the future depending on the sbt version.

(This may also occur in applications with a special class loader configuration, such as Play framework.)



This problem can be avoided by manually adding the classpath, but it is difficult for users to be aware of the dependency on scala-reflect.
```scala
engine.classpath = engine.classpath + ":" + "/Users/giiita/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.6/scala-reflect-2.13.6.jar"
engine.combinedClassPath = true
```