### PR TITLE
Mustache - add support for dotted names

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -1,6 +1,8 @@
-import sbt._, Keys._
+import sbt._
+import Keys._
 import com.typesafe.tools.mima.core.ProblemFilters
 import com.typesafe.tools.mima.core.IncompatibleSignatureProblem
+import com.typesafe.tools.mima.core.ReversedMissingMethodProblem
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaReportBinaryIssues}
@@ -26,7 +28,8 @@ object MimaSettings {
 
   val mimaSettings = Seq(
     ThisBuild / mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[IncompatibleSignatureProblem]("org.fusesource.scalate.*")
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("org.fusesource.scalate.*"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("org.fusesource.scalate.mustache.Scope.hasVariable")
     ),
     ThisBuild / mimaReportSignatureProblems := true,
     ThisBuild / mimaFailOnNoPrevious := false,

--- a/scalate-core/src/main/scala/org/fusesource/scalate/mustache/Scopes.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/mustache/Scopes.scala
@@ -43,6 +43,8 @@ case class RenderContextScope(
   def parent: Option[Scope] = _parent
 
   def localVariable(name: String): Option[Any] = context.attributes.get(name)
+
+  def hasVariable(name: String): Boolean = context.attributes.keySet.contains(name)
 }
 
 /**
@@ -69,6 +71,8 @@ case class MarkupAttributeContextScope(
         None
     }
   } else None
+
+  def hasVariable(name: String): Boolean = name == attributeName
 }
 
 abstract class ChildScope(parentScope: Scope) extends Scope {
@@ -86,6 +90,8 @@ class MapScope(
   map: collection.Map[String, _]) extends ChildScope(parent) {
 
   def localVariable(name: String): Option[Any] = map.get(name)
+
+  def hasVariable(name: String): Boolean = map.keySet.contains(name)
 }
 
 class NodeScope(
@@ -94,12 +100,16 @@ class NodeScope(
   node: NodeSeq) extends ChildScope(parent) {
 
   def localVariable(name: String): Option[Any] = Some(node \ name)
+
+  def hasVariable(name: String): Boolean = true
 }
 
 class EmptyScope(
   parent: Scope) extends ChildScope(parent) {
 
   def localVariable(name: String) = None
+
+  def hasVariable(name: String): Boolean = false
 }
 
 /**
@@ -112,6 +122,8 @@ class ObjectScope[T <: AnyRef](
   val introspector = Introspector[T](value.getClass.asInstanceOf[Class[T]])
 
   def localVariable(name: String) = introspector.get(name, value)
+
+  def hasVariable(name: String): Boolean = introspector.expressions.contains(name)
 
   override def iteratorObject = Some(value)
 }

--- a/scalate-core/src/main/scala/org/fusesource/scalate/mustache/VariableResult.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/mustache/VariableResult.scala
@@ -1,0 +1,41 @@
+package org.fusesource.scalate.mustache
+
+sealed trait VariableResult {
+  def toOption: Option[Any]
+
+  def flatMap(f: Any => VariableResult): VariableResult
+
+  def noVariableAsNoValue: VariableResult
+}
+
+object VariableResult {
+  case class SomeValue(value: Any) extends VariableResult {
+    def toOption: Option[Any] = Some(value)
+
+    def flatMap(f: Any => VariableResult): VariableResult = f(value)
+
+    def noVariableAsNoValue: VariableResult = this
+  }
+
+  case object NoValue extends VariableResult {
+    def toOption: Option[Any] = None
+
+    def flatMap(f: Any => VariableResult): VariableResult = this
+
+    def noVariableAsNoValue: VariableResult = this
+  }
+
+  case object NoVariable extends VariableResult {
+    def toOption: Option[Any] = None
+
+    def flatMap(f: Any => VariableResult): VariableResult = this
+
+    def noVariableAsNoValue: VariableResult = NoValue
+  }
+
+  def apply(maybeValue: Option[Any], variableExist: => Boolean): VariableResult = {
+    maybeValue.map(SomeValue).getOrElse {
+      if (variableExist) NoValue else NoVariable
+    }
+  }
+}

--- a/scalate-core/src/test/scala/org/fusesource/scalate/mustache/DottedNamesTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/mustache/DottedNamesTest.scala
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2009-2011 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.scalate.mustache
+
+/**
+ * Copyright (C) 2009-2010 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.fusesource.scalate.TemplateTestSupport
+
+/**
+ * Based on Mustache spec for Dotted Names:
+ * https://github.com/mustache/spec/blob/master/specs/interpolation.yml#L142
+ *
+ * @version $Revision: 1.1 $
+ */
+class DottedNamesTest extends TemplateTestSupport {
+  // Dotted names should be considered a form of shorthand for sections.
+  test("Basic Interpolation") {
+    assertMoustacheOutput("'Joe' == 'Joe'", "'{{person.name}}' == '{{#person}}{{name}}{{/person}}'", Map("person" -> Map("name" -> "Joe")))
+  }
+
+  // Dotted names should be considered a form of shorthand for sections.
+  test("Triple Mustache Interpolation") {
+    val data = Map("person" -> Map("name" -> "Joe"))
+    case class Person(name: String)
+    assertMoustacheOutput("'Joe' == 'Joe'", "'{{{person.name}}}' == '{{#person}}{{{name}}}{{/person}}'", data)
+  }
+
+  test("Nested section") {
+    assertMoustacheOutput("'Joe' == 'Joe'", "'{{details.person.name}}' == '{{#details}}{{#person}}{{name}}{{/person}}{{/details}}'", Map("details" -> Map("person" -> Map("name" -> "Joe"))))
+  }
+
+  test("Dotted name section") {
+    assertMoustacheOutput("'Joe' == 'Joe'", "'{{details.person.name}}' == '{{#details.person}}{{name}}{{/details.person}}'", Map("details" -> Map("person" -> Map("name" -> "Joe"))))
+  }
+
+  // Dotted names should be considered a form of shorthand for sections.
+  test("Triple Mustache Interpolation - object") {
+    case class Person(name: String)
+
+    val data = Map("person" -> Person("Joe"))
+    assertMoustacheOutput("'Joe' == 'Joe'", "'{{{person.name}}}' == '{{#person}}{{{name}}}{{/person}}'", data)
+  }
+
+  // Dotted names should be considered a form of shorthand for sections.
+  test("Ampersand Interpolation") {
+    assertMoustacheOutput("'Joe' == 'Joe'", "'{{&person.name}}' == '{{#person}}{{&name}}{{/person}}'", Map("person" -> Map("name" -> "Joe")))
+  }
+
+  // Dotted names should be functional to any level of nesting.
+  test("Arbitrary Depth") {
+    assertMoustacheOutput("'Phil' == 'Phil'", "'{{a.b.c.d.e.name}}' == 'Phil'", Map("a" -> Map("b" -> Map("c" -> Map("d" -> Map("e" -> Map("name" -> "Phil")))))))
+  }
+
+  // Any falsey value prior to the last part of the name should yield "".
+  test("Broken Chains") {
+    assertMoustacheOutput("'' == ''", "'{{a.b.c}}' == ''", Map("a" -> Map()))
+  }
+
+  // Each part of a dotted name should resolve only against its parent.
+  test("Broken Chain Resolution") {
+    val data = Map(
+      "a" -> Map("b" -> Map()),
+      "c" -> Map("name" -> "Jim"))
+    assertMoustacheOutput("'' == ''", "'{{a.b.c.name}}' == ''", data)
+  }
+
+  // The first part of a dotted name should resolve as any other name.
+  test("Initial Resolution") {
+    val data =
+      Map(
+        "a" -> Map("b" -> Map("c" -> Map("d" -> Map("e" -> Map("name" -> "Phil"))))),
+        "b" -> Map("c" -> Map("d" -> Map("e" -> Map("name" -> "Wrong")))))
+    assertMoustacheOutput("'Phil' == 'Phil'", "'{{#a}}{{b.c.d.e.name}}{{/a}}' == 'Phil'", data)
+  }
+
+  // Dotted names should be resolved against former resolutions.
+  test("Context Precedence") {
+    val data = Map(
+      "a" -> Map("b" -> Map()),
+      "b" -> Map("c" -> "ERROR"))
+    assertMoustacheOutput("", "{{#a}}{{b.c}}{{/a}}", data)
+  }
+
+  test("Context Precedence2") {
+    val data = Map(
+      "a" -> Map("b" -> "James"),
+      "b" -> "ERROR")
+    assertMoustacheOutput("James", "{{#a}}{{b}}{{/a}}", data)
+  }
+
+  test("List test 1") {
+    val names = List("Hiram", "James")
+
+    assertMoustacheOutput(
+      "start <Hiram> <James> end",
+      "start {{#names}}<{{.}}> {{/names}}end",
+      Map("names" -> names))
+  }
+
+  test("List test 2") {
+    val persons = List(Map("name" -> "Hiram"), Map("name" -> "James"))
+
+    assertMoustacheOutput(
+      "start <Hiram> <James> end",
+      "start {{#persons}}<{{name}}> {{/persons}}end",
+      Map("persons" -> persons))
+  }
+
+  test("List test 3") {
+    val persons = List(Map("name" -> "Hiram"), Map("name" -> "James"))
+
+    assertMoustacheOutput(
+      "start <Hiram> <James> end",
+      "start {{#all.persons}}<{{name}}> {{/all.persons}}end",
+      Map("all" -> Map("persons" -> persons)))
+  }
+
+}
+

--- a/scalate-core/src/test/scala/org/fusesource/scalate/mustache/MustacheJsSystemTest.scala
+++ b/scalate-core/src/test/scala/org/fusesource/scalate/mustache/MustacheJsSystemTest.scala
@@ -17,6 +17,7 @@
  */
 package org.fusesource.scalate.mustache
 
+import java.util.Locale
 import collection.immutable.Map
 
 case class Item(name: String, current: Boolean, url: String) {
@@ -39,6 +40,7 @@ case class HigherOrder(name: String, helper: String) {
  * Runs the system tests from the mustache.js distro
  */
 class MustacheJsSystemTest extends MustacheTestSupport {
+  Locale.setDefault(Locale.US)
   // TODO FixMe
   val runFailingTests = false
 


### PR DESCRIPTION
Mustache specification defines "dot notation" or "dotted names" for example:
```
{{person.name}}
```
see https://github.com/mustache/spec/blob/master/specs/interpolation.yml#L142-L198

This PR adds to scalate mustache support for dotted names.
It is implemented in Scope trait plus unit tests in DottedNamesTest (based on examples from mustache specification)
