### PR TITLE
remove markdown from class loader in favor of in-code

### DIFF
--- a/scalate-core/src/main/resources/META-INF/services/org.fusesource.scalate/addon.index
+++ b/scalate-core/src/main/resources/META-INF/services/org.fusesource.scalate/addon.index
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-org.fusesource.scalate.filter.ScalaMarkdownFilter
+#org.fusesource.scalate.filter.ScalaMarkdownFilter

--- a/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
+++ b/scalate-core/src/main/scala/org/fusesource/scalate/TemplateEngine.scala
@@ -214,6 +214,10 @@ class TemplateEngine(
   attempt(filters += "escaped" -> EscapedFilter)
 
   attempt {
+    ScalaMarkdownFilter(this)
+  }
+
+  attempt {
     CoffeeScriptPipeline(this)
   }
 


### PR DESCRIPTION
Opening an issue, so TBD, this is more artifact base for POC and engineering discussions, more to come...

A common issue found in our test and production environment is when multi threaded and single-use template engines are used the class loader can sometimes load the class of another classloader - causing a type conversion for the below error:

```
java.lang.ClassCastException: org.fusesource.scalate.filter.ScalaMarkdownFilter$ cannot be cast to org.fusesource.scalate.TemplateEngineAddOn
```