### PR TITLE
Added .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.pin  = [ { groupId = "ch.qos.logback", artifactId="logback-classic", version = "1.3." } ]


### PR DESCRIPTION
Since logback-classic 1.4 supports Java 11 or later.