### PR TITLE
Added entry for spring-mvc 5.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,4 @@
-updates.pin  = [ { groupId = "ch.qos.logback", artifactId="logback-classic", version = "1.3." } ]
+updates.pin  = [
+  { groupId = "ch.qos.logback", artifactId="logback-classic", version = "1.3." },
+  { groupId = "org.springframework", artifactId="spring-webmvc", version = "5." }
+]


### PR DESCRIPTION
spring-mvc 6.0 will remain 5.x for the time being, as it is supported by Java 17 and above.