### PR TITLE
Updated JAXRS API version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val atmosphereJersey = "org.atmosphere" % "atmosphere-jersey" % "0.8.7"
   val javaxServlet = "javax.servlet" % "servlet-api" % "2.5"
   val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.1"
-  val jaxrsApi = "org.jboss.spec.javax.ws.rs" % "jboss-jaxrs-api_1.1_spec" % "1.0.1.Final"
+  val jaxrsApi = "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6"
   val jerseyCore = "com.sun.jersey" % "jersey-core" % "1.19.4"
   val jerseyServlet = "com.sun.jersey" % "jersey-servlet" % jerseyCore.revision
   val jerseyGuice = "com.sun.jersey.contribs" % "jersey-guice" % jerseyCore.revision

--- a/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/NodeWriter.scala
+++ b/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/NodeWriter.scala
@@ -39,8 +39,6 @@ class NodeWriter extends MessageBodyWriter[NodeSeq] {
     classOf[NodeSeq].isAssignableFrom(aClass)
   }
 
-  def getSize(nodes: NodeSeq, aClass: Class[_], aType: Type, annotations: Array[Annotation], mediaType: MediaType) = -1L
-
   def writeTo(nodes: NodeSeq, aClass: Class[_], aType: Type, annotations: Array[Annotation], mediaType: MediaType, stringObjectMultivaluedMap: MultivaluedMap[String, Object], outputStream: OutputStream): Unit = {
     val answer = nodes.toString();
     outputStream.write(answer.getBytes());

--- a/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ScalateTemplateProvider.scala
+++ b/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ScalateTemplateProvider.scala
@@ -64,8 +64,6 @@ class ScalateTemplateProvider extends MessageBodyWriter[AnyRef] {
     }.orNull
   }
 
-  def getSize(arg: AnyRef, argType: Class[_], genericType: Type, annotations: Array[Annotation], mediaType: MediaType) = -1L
-
   def isWriteable(argType: Class[_], genericType: Type, annotations: Array[Annotation], mediaType: MediaType) = {
     var answer = false
     if (mediaType.getType == "text" && mediaType.getSubtype == "html") {

--- a/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ViewWriter.scala
+++ b/scalate-jaxrs/src/main/scala/org/fusesource/scalate/rest/ViewWriter.scala
@@ -75,8 +75,6 @@ class ViewWriter[T] extends MessageBodyWriter[View[T]] {
     classOf[View[T]].isAssignableFrom(aClass)
   }
 
-  def getSize(view: View[T], aClass: Class[_], aType: Type, annotations: Array[Annotation], mediaType: MediaType) = -1L
-
   def writeTo(view: View[T], aClass: Class[_], aType: Type, annotations: Array[Annotation], mediaType: MediaType, httpHeaders: MultivaluedMap[String, Object], out: OutputStream): Unit = {
     def render(template: String) = TemplateEngineServlet.render(template, engine, servletContext, request, response)
 

--- a/scalate-jersey/src/main/scala/org/fusesource/scalate/rest/TransformerWriter.scala
+++ b/scalate-jersey/src/main/scala/org/fusesource/scalate/rest/TransformerWriter.scala
@@ -67,13 +67,6 @@ class TransformerWriter extends MessageBodyWriter[Transformer] {
     classOf[Transformer].isAssignableFrom(aClass)
   }
 
-  def getSize(
-    transformer: Transformer,
-    aClass: Class[_],
-    aType: Type,
-    annotations: Array[Annotation],
-    mediaType: MediaType) = -1L
-
   def writeTo(
     transformer: Transformer,
     aClass: Class[_],


### PR DESCRIPTION
JAXRS API package was out of date, replaced with the latest

MessageBodyWriter#getSize was removed, as a default implementation is now provided and implementation in inherited classes is no longer required.