### PR TITLE
Fix JDK 9+ classloader introspection warnings

### DIFF
--- a/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassPathBuilder.scala
+++ b/scalate-util/src/main/scala/org/fusesource/scalate/util/ClassPathBuilder.scala
@@ -20,8 +20,6 @@ package org.fusesource.scalate.util
 import java.io.File
 import java.net.{ URI, URLClassLoader }
 import java.util.jar.{ Attributes, JarFile }
-import scala.annotation.tailrec
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.language.reflectiveCalls
 
@@ -142,8 +140,14 @@ private object ClassPathBuilder extends Log {
         cp.split(File.pathSeparator).toIndexedSeq
 
       case _ =>
-        warn("Cannot introspect on class loader: %s of type %s", classLoader, classLoader.getClass.getCanonicalName)
-        Nil
+        if (classLoader eq ClassLoader.getSystemClassLoader) {
+          javaClassPath
+        } else if (classLoader.getClass.getName == "jdk.internal.loader.ClassLoaders$PlatformClassLoader") {
+          Nil
+        } else {
+          warn("Cannot introspect on class loader: %s of type %s", classLoader, classLoader.getClass.getName)
+          Nil
+        }
     }
 
     Option(classLoader).flatMap(x => Option(x.getParent)).fold(paths) {

--- a/scalate-util/src/test/scala/org/fusesource/scalate/util/ClassPathBuilderTest.scala
+++ b/scalate-util/src/test/scala/org/fusesource/scalate/util/ClassPathBuilderTest.scala
@@ -122,6 +122,12 @@ class ClassPathBuilderTest extends FunSuiteSupport {
     assert(builder.classPath.contains("fake-jar"))
   }
 
+  test("Add path from JDK 9+ system classloader") {
+    val builder = new ClassPathBuilder
+    builder.addPathFrom(ClassLoader.getSystemClassLoader)
+    assert(builder.classPath.nonEmpty || builder.classPath === "")
+  }
+
   test("Contains the classpaths of all class loaders including parents") {
     assume(!System.getProperty("os.name").toLowerCase.contains("windows"))
 


### PR DESCRIPTION
## Summary
- Handle JDK 9+ AppClassLoader via `ClassLoader.getSystemClassLoader` reference equality
- Handle PlatformClassLoader via `ClassLoader.getPlatformClassLoader` reference equality
- Removes noisy WARN log messages on JDK 11+
- Ref https://github.com/scalate/scalate/issues/218